### PR TITLE
Feature: Add output parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ scripts:
 
 ## Prometheus configuration
 
-The script exporter needs to be passed the script name as a parameter (`script`). You can also pass a custom prefix (`prefix`) and additional parameters which should be passed to the script (`params`).
+The script exporter needs to be passed the script name as a parameter (`script`). You can also pass a custom prefix (`prefix`) and additional parameters which should be passed to the script (`params`). If the `output` parameter is set to `ignore` then the script exporter only return `script_success{}` and `script_duration_seconds{}`.
 
 Example config:
 
@@ -115,6 +115,7 @@ scrape_configs:
       script: [ping]
       prefix: [script_ping]
       params: [target]
+      output: [ignore]
     static_configs:
       - targets:
         - example.com

--- a/cmd/script_exporter/script_exporter.go
+++ b/cmd/script_exporter/script_exporter.go
@@ -89,6 +89,13 @@ func metricsHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// Get ignore output parameter and only return success and duration seconds if 'true'
+	outputParam := params.Get("output")
+	if outputParam == "ignore" {
+		fmt.Fprintf(w, "%s\n%s\n%s_success{} %d\n%s\n%s\n%s_duration_seconds{} %f\n", scriptSuccessHelp, scriptSuccessType, namespace, 1, scriptDurationSecondsHelp, scriptDurationSecondsType, namespace, time.Since(scriptStartTime).Seconds())
+		return
+	}
+
 	// Format output
 	regex1, _ := regexp.Compile("^" + prefix + "\\w*{.*}\\s+")
 	regex2, _ := regexp.Compile("^" + prefix + "\\w*{.*}\\s+[0-9|\\.]*")


### PR DESCRIPTION
The `output` parameter controls the handlign of the executed script output. If the parameter is set to `ignore` the output of the executed script is ignored and the script exporter only returns `script_success{}` and `script_duration_seconds{}`.