### PR TITLE
Expose internal metrics for script_exporter with associated changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,10 +25,11 @@ Running:
 
 Then visit [http://localhost:9469](http://localhost:9469) in the browser of your choice. There you have access to the following examples:
 
-- [test](http://localhost:9469/metrics?script=test&prefix=test): Invalid values which are returned by the script are omitted.
-- [ping](http://localhost:9469/metrics?script=ping&prefix=test&params=target&target=example.com): Pings the specified address in the `target` parameter and returns if it was successful or not.
-- [helloworld](http://localhost:9469/metrics?script=helloworld): Returns the specified argument in the `script` as label.
-- [curltest](http://localhost:9469/metrics?script=curltest&params=target&target=https://example.com): Runs a binary, which performs a get request against the specified `target` and returns the status code.
+- [test](http://localhost:9469/probe?script=test&prefix=test): Invalid values which are returned by the script are omitted.
+- [ping](http://localhost:9469/probe?script=ping&prefix=test&params=target&target=example.com): Pings the specified address in the `target` parameter and returns if it was successful or not.
+- [helloworld](http://localhost:9469/probe?script=helloworld): Returns the specified argument in the `script` as label.
+- [curltest](http://localhost:9469/probe?script=curltest&params=target&target=https://example.com): Runs a binary, which performs a get request against the specified `target` and returns the status code.
+- [metrics](http://localhost:9469/metrics): Shows internal metrics from the script exporter.
 
 ## Usage and configuration
 
@@ -46,8 +47,6 @@ Usage of ./bin/script_exporter:
     	Show version information.
   -web.listen-address string
     	Address to listen on for web interface and telemetry. (default ":9469")
-  -web.telemetry-path string
-    	Path under which to expose metrics. (default "/metrics")
 ```
 
 The configuration file is written in YAML format, defined by the scheme described below.
@@ -85,7 +84,7 @@ Example config:
 ```yaml
 scrape_configs:
   - job_name: 'script_test'
-    metrics_path: /metrics
+    metrics_path: /probe
     params:
       script: [test]
       prefix: [script]
@@ -98,7 +97,7 @@ scrape_configs:
   - job_name: 'script_ping'
     scrape_interval: 1m
     scrape_timeout: 30s
-    metrics_path: /metrics
+    metrics_path: /probe
     params:
       script: [ping]
       prefix: [script_ping]
@@ -116,9 +115,21 @@ scrape_configs:
         target_label: target
       - source_labels: [__param_target]
         target_label: instance
+
+  - job_name: 'script_exporter'
+    metrics_path: /metrics
+    static_configs:
+      - targets:
+        - 127.0.0.1:9469
 ```
+
+## Breaking changes
+
+Changes from version 1.3.0:
+- The command line flag ``-web.telemetry-path`` has been removed and its value is now always ``/probe``, which is a change from the previous default of ``/metrics``. The path ``/metrics`` now responds with Prometheus metrics for script_exporter itself.
 
 ## Dependencies
 
 - [yaml.v2 - YAML support for the Go language](gopkg.in/yaml.v2)
 - [jwt-go - Golang implementation of JSON Web Tokens (JWT)](github.com/dgrijalva/jwt-go)
+- [prometheus client_golang - Prometheus instrumentation library for Go applications](https://github.com/prometheus/client_golang/)

--- a/README.md
+++ b/README.md
@@ -39,8 +39,6 @@ The script_exporter is configured via a configuration file and command-line flag
 Usage of ./bin/script_exporter:
   -config.file string
     	Configuration file in YAML format. (default "config.yaml")
-  -config.shell string
-    	Set shell to execute scripts with; otherwise they are executed directly
   -create-token
     	Create bearer token for authentication.
   -version
@@ -71,7 +69,7 @@ scripts:
     script: <string>
 ```
 
-The `script` string will be split on spaces to generate the program name and any fixed arguments, then any arguments specified from the `params` parameter will be appended. If a shell has not been set, the program will be executed directly; if a shell has been set, the shell will be used to run the script, executed as `SHELL script-name [argument ...]`. If a shell is set, what it runs must be a shell script (and for that shell); it cannot be a binary executable and any `#!` line at the start is ignored.
+The `script` string will be split on spaces to generate the program name and any fixed arguments, then any arguments specified from the `params` parameter will be appended. The program will be executed directly, without a shell being invoked, and it is recommended that it be specified by path instead of relying on ``$PATH``.
 
 ## Prometheus configuration
 
@@ -127,6 +125,7 @@ scrape_configs:
 
 Changes from version 1.3.0:
 - The command line flag ``-web.telemetry-path`` has been removed and its value is now always ``/probe``, which is a change from the previous default of ``/metrics``. The path ``/metrics`` now responds with Prometheus metrics for script_exporter itself.
+- The command line flag ``-config.shell`` has been removed. Programs are now always run directly.
 
 ## Dependencies
 

--- a/cmd/script_exporter/script_exporter.go
+++ b/cmd/script_exporter/script_exporter.go
@@ -1,3 +1,6 @@
+// Script_exporter is a Prometheus exporter to execute programs and
+// scripts and collect metrics from their output and their exit
+// status.
 package main
 
 import (
@@ -153,7 +156,6 @@ func metricsHandler(w http.ResponseWriter, r *http.Request) {
 	}
 
 	fmt.Fprintf(w, "%s\n%s\n%s_success{} %d\n%s\n%s\n%s_duration_seconds{} %f\n%s\n", scriptSuccessHelp, scriptSuccessType, namespace, 1, scriptDurationSecondsHelp, scriptDurationSecondsType, namespace, time.Since(scriptStartTime).Seconds(), formatedOutput)
-	return
 }
 
 // setupMetrics creates and registers our internal Prometheus metrics,
@@ -297,7 +299,7 @@ func main() {
 		</html>`))
 	})
 
-	if exporterConfig.TLS.Active == true {
+	if exporterConfig.TLS.Active {
 		log.Fatalln(http.ListenAndServeTLS(*listenAddress, exporterConfig.TLS.Crt, exporterConfig.TLS.Key, nil))
 	} else {
 		log.Fatalln(http.ListenAndServe(*listenAddress, nil))

--- a/cmd/script_exporter/script_exporter.go
+++ b/cmd/script_exporter/script_exporter.go
@@ -34,17 +34,12 @@ var (
 	showVersion   = flag.Bool("version", false, "Show version information.")
 	createToken   = flag.Bool("create-token", false, "Create bearer token for authentication.")
 	configFile    = flag.String("config.file", "config.yaml", "Configuration file in YAML format.")
-	shell         = flag.String("config.shell", "", "Set shell to execute scripts with; otherwise they are executed directly")
 )
 
 func runScript(args []string) (string, error) {
 	var output []byte
 	var err error
-	if *shell != "" {
-		output, err = exec.Command(*shell, args...).Output()
-	} else {
-		output, err = exec.Command(args[0], args[1:]...).Output()
-	}
+	output, err = exec.Command(args[0], args[1:]...).Output()
 	if err != nil {
 		return "", err
 	}

--- a/go.mod
+++ b/go.mod
@@ -2,5 +2,6 @@ module github.com/ricoberger/script_exporter
 
 require (
 	github.com/dgrijalva/jwt-go v3.2.0+incompatible
+	github.com/prometheus/client_golang v1.0.0
 	gopkg.in/yaml.v2 v2.2.2
 )


### PR DESCRIPTION
This pull request implements three changes, two requested and one unprompted:
* expose internal metrics for script_exporter on ``/metrics``, hard-coding the script endpoint as ``/probes`` (to match Blackbox) and removing the ``-web.telemetry-path`` command line option.
* always run ``script:`` programs directly, removing the ``-config.shell`` command line option.
* minor cleanups from complaints by [staticcheck](https://staticcheck.io/)

I have done my best to update the README for these changes.

Closes #8