### PR TITLE
Add ARMv7 (Raspberry Pi 2 target) to Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -51,6 +51,16 @@ build-windows-amd64:
 			-o ./bin/$$target-${VERSION}-windows-amd64.exe ./cmd/$$target; \
 	done
 
+build-linux-armv7:
+    for target in $(WHAT); do \
+        CGO_ENABLED=0 GOARCH=arm GOARM=7 GOOS=linux go build -a -installsuffix cgo -ldflags "-X ${REPO}/pkg/version.Version=${VERSION} \
+            -X ${REPO}/pkg/version.Revision=${REVISION} \
+            -X ${REPO}/pkg/version.Branch=${BRANCH} \
+            -X ${REPO}/pkg/version.BuildUser=${BUILDUSER} \
+            -X ${REPO}/pkg/version.BuildDate=${BUILDTIME}" \
+            -o ./bin/$$target-${VERSION}-linux-armv7 ./cmd/$$target; \
+    done
+
 clean:
 	rm -rf ./bin
 

--- a/Makefile
+++ b/Makefile
@@ -52,14 +52,14 @@ build-windows-amd64:
 	done
 
 build-linux-armv7:
-    for target in $(WHAT); do \
-        CGO_ENABLED=0 GOARCH=arm GOARM=7 GOOS=linux go build -a -installsuffix cgo -ldflags "-X ${REPO}/pkg/version.Version=${VERSION} \
-            -X ${REPO}/pkg/version.Revision=${REVISION} \
-            -X ${REPO}/pkg/version.Branch=${BRANCH} \
-            -X ${REPO}/pkg/version.BuildUser=${BUILDUSER} \
-            -X ${REPO}/pkg/version.BuildDate=${BUILDTIME}" \
-            -o ./bin/$$target-${VERSION}-linux-armv7 ./cmd/$$target; \
-    done
+	for target in $(WHAT); do \
+		CGO_ENABLED=0 GOARCH=arm GOARM=7 GOOS=linux go build -a -installsuffix cgo -ldflags "-X ${REPO}/pkg/version.Version=${VERSION} \
+			-X ${REPO}/pkg/version.Revision=${REVISION} \
+			-X ${REPO}/pkg/version.Branch=${BRANCH} \
+			-X ${REPO}/pkg/version.BuildUser=${BUILDUSER} \
+			-X ${REPO}/pkg/version.BuildDate=${BUILDTIME}" \
+			-o ./bin/$$target-${VERSION}-linux-armv7 ./cmd/$$target; \
+	done
 
 clean:
 	rm -rf ./bin


### PR DESCRIPTION
I added (based on the other examples) the ARMv7 architecture to the Makefile.
I supose that you can add ARM64 (Raspberry Pi 3) with GOARCH=arm64 based on  https://github.com/golang/go/wiki/GoArm but I can't test it, so I don't add it.

I didn't add the new arch to the "release" target list, but it should work if you add it and generate binaries to be added on "releases" tab.