### PR TITLE
Expose scrape timeouts to scripts, with optional enforcement of them

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,7 @@ bearerAuth:
 timeouts:
   # in seconds, default 0 (no maximum)
   max_timeout: <float>
+  enforced: <boolean>
 
 scripts:
   - name: <string>
@@ -77,13 +78,14 @@ scripts:
     # optional
     timeout:
       max_timeout: <float>
+      enforced: <boolean>
 ```
 
 The `script` string will be split on spaces to generate the program name and any fixed arguments, then any arguments specified from the `params` parameter will be appended. The program will be executed directly, without a shell being invoked, and it is recommended that it be specified by path instead of relying on ``$PATH``.
 
-Prometheus will normally provide an indication of its scrape timeout to the script exporter (through a special HTTP header). This information is made available to scripts through the environment variables `$SCRIPT_TIMEOUT` and `$SCRIPT_DEADLINE`. The first is the timeout in seconds (including a fractional part) and the second is the Unix timestamp when the deadline will expire (also including a fractional part). A simple script could implement this timeout by starting with `timeout "$SCRIPT_TIMEOUT" cmd ...`. A more sophisticated program might want to use the deadline time to compute internal timeouts for various operation.
+Prometheus will normally provide an indication of its scrape timeout to the script exporter (through a special HTTP header). This information is made available to scripts through the environment variables `$SCRIPT_TIMEOUT` and `$SCRIPT_DEADLINE`. The first is the timeout in seconds (including a fractional part) and the second is the Unix timestamp when the deadline will expire (also including a fractional part). A simple script could implement this timeout by starting with `timeout "$SCRIPT_TIMEOUT" cmd ...`. A more sophisticated program might want to use the deadline time to compute internal timeouts for various operation. If `enforced` is true, either globally or for the script, `script_exporter` attempts to enforce the timeout by killing the script's main process after the timeout expires. The default is to not enforce timeouts.
 
-For testing purposes, this timeout can be specified directly as a URL parameter (`timeout`). If present, the URL parameter takes priority over the Prometheus HTTP header. If `max_timeout` is set in the configuration file, it limits the maximum timeout value that HTTP requests can specify. A `max_timeout` of 0 means no limit, allowing a script to remove a general `max_timeout`.
+For testing purposes, the timeout can be specified directly as a URL parameter (`timeout`). If present, the URL parameter takes priority over the Prometheus HTTP header. If `max_timeout` is set in the configuration file, it limits the maximum timeout value that HTTP requests can specify. A `max_timeout` of 0 means no limit, allowing a script to remove a general `max_timeout`.
 
 ## Prometheus configuration
 

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ The script_exporter is configured via a configuration file and command-line flag
 
 ```
 Usage of ./bin/script_exporter:
-  -config.file string
+  -config.file file
     	Configuration file in YAML format. (default "config.yaml")
   -create-token
     	Create bearer token for authentication.

--- a/README.md
+++ b/README.md
@@ -67,25 +67,21 @@ bearerAuth:
   active: <boolean>
   signingKey: <string>
 
-timeouts:
-  # in seconds, default 0 (no maximum)
-  max_timeout: <float>
-  enforced: <boolean>
-
 scripts:
   - name: <string>
     script: <string>
     # optional
     timeout:
+      # in seconds, 0 or negative means none
       max_timeout: <float>
       enforced: <boolean>
 ```
 
 The `script` string will be split on spaces to generate the program name and any fixed arguments, then any arguments specified from the `params` parameter will be appended. The program will be executed directly, without a shell being invoked, and it is recommended that it be specified by path instead of relying on ``$PATH``.
 
-Prometheus will normally provide an indication of its scrape timeout to the script exporter (through a special HTTP header). This information is made available to scripts through the environment variables `$SCRIPT_TIMEOUT` and `$SCRIPT_DEADLINE`. The first is the timeout in seconds (including a fractional part) and the second is the Unix timestamp when the deadline will expire (also including a fractional part). A simple script could implement this timeout by starting with `timeout "$SCRIPT_TIMEOUT" cmd ...`. A more sophisticated program might want to use the deadline time to compute internal timeouts for various operation. If `enforced` is true, either globally or for the script, `script_exporter` attempts to enforce the timeout by killing the script's main process after the timeout expires. The default is to not enforce timeouts.
+Prometheus will normally provide an indication of its scrape timeout to the script exporter (through a special HTTP header). This information is made available to scripts through the environment variables `$SCRIPT_TIMEOUT` and `$SCRIPT_DEADLINE`. The first is the timeout in seconds (including a fractional part) and the second is the Unix timestamp when the deadline will expire (also including a fractional part). A simple script could implement this timeout by starting with `timeout "$SCRIPT_TIMEOUT" cmd ...`. A more sophisticated program might want to use the deadline time to compute internal timeouts for various operation. If `enforced` is true, `script_exporter` attempts to enforce the timeout by killing the script's main process after the timeout expires. The default is to not enforce timeouts. If `max_timeout` is set for a script, it limits the maximum timeout value that requests can specify; a request that specifies a larger timeout will have the timeout adjusted down to the `max_timeout` value.
 
-For testing purposes, the timeout can be specified directly as a URL parameter (`timeout`). If present, the URL parameter takes priority over the Prometheus HTTP header. If `max_timeout` is set in the configuration file, it limits the maximum timeout value that HTTP requests can specify. A `max_timeout` of 0 means no limit, allowing a script to remove a general `max_timeout`.
+For testing purposes, the timeout can be specified directly as a URL parameter (`timeout`). If present, the URL parameter takes priority over the Prometheus HTTP header.
 
 ## Prometheus configuration
 

--- a/cmd/script_exporter/script_exporter.go
+++ b/cmd/script_exporter/script_exporter.go
@@ -5,6 +5,7 @@ package main
 
 import (
 	"bufio"
+	"context"
 	"flag"
 	"fmt"
 	"log"
@@ -45,11 +46,45 @@ var (
 // args[0]. The timeout argument is in seconds, and if it's larger
 // than zero, it is exported into the environment as $SCRIPT_TIMEOUT
 // (its raw value) and $SCRIPT_DEADLINE, which is the Unix timestamp
-// (including fractional parts) when the deadline will expire.
-func runScript(timeout float64, args []string) (string, error) {
+// (including fractional parts) when the deadline will expire. If
+// enforced is true, the timeout will be enforced by script_exporter,
+// by killing the script if the timeout is reached, and
+// $SCRIPT_TIMEOUT_ENFORCED will be set to 1 in the environment to
+// inform the script of this.
+//
+// Note that killing the script is only a best effort attempt to
+// terminate its execution and time out the request. Sub-processes may
+// not be terminated, and termination may not be entirely successful.
+//
+// Tentatively, we do not inherit the context from the HTTP request.
+// Doing so would provide automatic termination should the client
+// close the connection, but it would mean that all scripts would
+// be subject to abrupt termination regardless of any 'enforced:'
+// settings. Right now, abrupt termination requires opting in in
+// the configuration file.
+func runScript(timeout float64, enforced bool, args []string) (string, error) {
 	var output []byte
 	var err error
-	cmd := exec.Command(args[0], args[1:]...)
+
+	// We go through a great deal of work to get a deadline with
+	// fractional seconds that we can expose in an environment
+	// variable. However, this is pretty much necessary since
+	// we've copied Blackbox's default of a half second adjustment
+	// to the raw Prometheus timeout.  We can hardly do that and
+	// then round our deadlines (or our raw timeouts) off to full
+	// seconds.
+	ns := float64(time.Second)
+	deadline := time.Now().Add(time.Duration(timeout * ns))
+	dlfractional := float64(deadline.UnixNano()) / ns
+
+	var cmd *exec.Cmd
+	var cancel context.CancelFunc
+	ctx := context.Background()
+	if timeout > 0 && enforced {
+		ctx, cancel = context.WithDeadline(context.Background(), deadline)
+		defer cancel()
+	}
+	cmd = exec.CommandContext(ctx, args[0], args[1:]...)
 
 	if timeout > 0 {
 		cmd.Env = os.Environ()
@@ -58,17 +93,12 @@ func runScript(timeout float64, args []string) (string, error) {
 		// running external programs. But better slightly excessive
 		// than not enough precision.
 		cmd.Env = append(cmd.Env, fmt.Sprintf("SCRIPT_TIMEOUT=%0.3f", timeout))
-
-		// We go through a great deal of work to get a deadline
-		// with fractional seconds. However, this is pretty much
-		// necessary since we've copied Blackbox's default of a
-		// half second adjustment to the raw Prometheus timeout.
-		// We can hardly do that and then round our deadlines
-		// (or our raw timeouts) off to full seconds.
-		ns := float64(time.Second)
-		deadline := time.Now().Add(time.Duration(timeout * ns))
-		dlfractional := float64(deadline.UnixNano()) / ns
 		cmd.Env = append(cmd.Env, fmt.Sprintf("SCRIPT_DEADLINE=%0.3f", dlfractional))
+		var ienforced int
+		if enforced {
+			ienforced = 1
+		}
+		cmd.Env = append(cmd.Env, fmt.Sprintf("SCRIPT_TIMEOUT_ENFORCED=%d", ienforced))
 	}
 
 	output, err = cmd.Output()
@@ -177,7 +207,7 @@ func metricsHandler(w http.ResponseWriter, r *http.Request) {
 	// configuration file.
 	timeout := getTimeout(r, *timeoutOffset, exporterConfig.GetMaxTimeout(scriptName))
 
-	output, err := runScript(timeout, append(strings.Split(script, " "), paramValues...))
+	output, err := runScript(timeout, exporterConfig.GetTimeoutEnforced(scriptName), append(strings.Split(script, " "), paramValues...))
 	if err != nil {
 		log.Printf("Script failed: %s\n", err.Error())
 		fmt.Fprintf(w, "%s\n%s\n%s_success{} %d\n%s\n%s\n%s_duration_seconds{} %f\n", scriptSuccessHelp, scriptSuccessType, namespace, 0, scriptDurationSecondsHelp, scriptDurationSecondsType, namespace, time.Since(scriptStartTime).Seconds())

--- a/cmd/script_exporter/script_exporter.go
+++ b/cmd/script_exporter/script_exporter.go
@@ -38,7 +38,7 @@ var (
 	listenAddress = flag.String("web.listen-address", ":9469", "Address to listen on for web interface and telemetry.")
 	showVersion   = flag.Bool("version", false, "Show version information.")
 	createToken   = flag.Bool("create-token", false, "Create bearer token for authentication.")
-	configFile    = flag.String("config.file", "config.yaml", "Configuration file in YAML format.")
+	configFile    = flag.String("config.file", "config.yaml", "Configuration `file` in YAML format.")
 	timeoutOffset = flag.Float64("timeout-offset", 0.5, "Offset to subtract from Prometheus-supplied timeout in `seconds`.")
 )
 
@@ -340,6 +340,12 @@ func main() {
 
 		fmt.Fprintln(os.Stdout, v)
 		os.Exit(0)
+	}
+
+	// Avoid problems by erroring out if we have any remaining
+	// arguments, instead of silently ignoring them.
+	if len(flag.Args()) != 0 {
+		log.Fatalf("Usage error: program takes no arguments, only options.")
 	}
 
 	// Load configuration file

--- a/cmd/script_exporter/script_exporter.go
+++ b/cmd/script_exporter/script_exporter.go
@@ -12,6 +12,7 @@ import (
 	"os"
 	"os/exec"
 	"regexp"
+	"strconv"
 	"strings"
 	"time"
 
@@ -37,17 +38,72 @@ var (
 	showVersion   = flag.Bool("version", false, "Show version information.")
 	createToken   = flag.Bool("create-token", false, "Create bearer token for authentication.")
 	configFile    = flag.String("config.file", "config.yaml", "Configuration file in YAML format.")
+	timeoutOffset = flag.Float64("timeout-offset", 0.5, "Offset to subtract from Prometheus-supplied timeout in `seconds`.")
 )
 
-func runScript(args []string) (string, error) {
+// runScript runs a program with some arguments; the program is
+// args[0]. The timeout argument is in seconds, and if it's larger
+// than zero, it is exported into the environment as $SCRIPT_TIMEOUT
+// (its raw value) and $SCRIPT_DEADLINE, which is the Unix timestamp
+// (including fractional parts) when the deadline will expire.
+func runScript(timeout float64, args []string) (string, error) {
 	var output []byte
 	var err error
-	output, err = exec.Command(args[0], args[1:]...).Output()
+	cmd := exec.Command(args[0], args[1:]...)
+
+	if timeout > 0 {
+		cmd.Env = os.Environ()
+		// Three digits of fractional precision in the seconds and
+		// the deadline are probably excessive, given that we're
+		// running external programs. But better slightly excessive
+		// than not enough precision.
+		cmd.Env = append(cmd.Env, fmt.Sprintf("SCRIPT_TIMEOUT=%0.3f", timeout))
+
+		// We go through a great deal of work to get a deadline
+		// with fractional seconds. However, this is pretty much
+		// necessary since we've copied Blackbox's default of a
+		// half second adjustment to the raw Prometheus timeout.
+		// We can hardly do that and then round our deadlines
+		// (or our raw timeouts) off to full seconds.
+		ns := float64(time.Second)
+		deadline := time.Now().Add(time.Duration(timeout * ns))
+		dlfractional := float64(deadline.UnixNano()) / ns
+		cmd.Env = append(cmd.Env, fmt.Sprintf("SCRIPT_DEADLINE=%0.3f", dlfractional))
+	}
+
+	output, err = cmd.Output()
 	if err != nil {
 		return "", err
 	}
 
 	return string(output), nil
+}
+
+// getTimeout gets the Prometheus scrape timeout (in seconds) from the
+// HTTP request, either from a 'timeout' query parameter or from the
+// special HTTP header that Prometheus inserts on scrapes, and returns
+// it or 0 on error.  If there is a timeout, it is modified down by
+// the offset.
+func getTimeout(r *http.Request, offset float64, maxTimeout float64) float64 {
+	v := r.URL.Query().Get("timeout")
+	if v == "" {
+		v = r.Header.Get("X-Prometheus-Scrape-Timeout-Seconds")
+	}
+	if v == "" {
+		return 0
+	}
+	ts, err := strconv.ParseFloat(v, 64)
+	adjusted := ts - offset
+	switch {
+	case err != nil:
+		return 0
+	case maxTimeout < adjusted && maxTimeout > 0:
+		return maxTimeout
+	case adjusted <= 0:
+		return 0
+	default:
+		return adjusted
+	}
 }
 
 // instrumentScript wraps the underlying http.Handler with Prometheus
@@ -116,7 +172,12 @@ func metricsHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	output, err := runScript(append(strings.Split(script, " "), paramValues...))
+	// Get the timeout from either Prometheus's HTTP header or a URL
+	// query parameter, clamped to a maximum specified through the
+	// configuration file.
+	timeout := getTimeout(r, *timeoutOffset, exporterConfig.GetMaxTimeout(scriptName))
+
+	output, err := runScript(timeout, append(strings.Split(script, " "), paramValues...))
 	if err != nil {
 		log.Printf("Script failed: %s\n", err.Error())
 		fmt.Fprintf(w, "%s\n%s\n%s_success{} %d\n%s\n%s\n%s_duration_seconds{} %f\n", scriptSuccessHelp, scriptSuccessType, namespace, 0, scriptDurationSecondsHelp, scriptDurationSecondsType, namespace, time.Since(scriptStartTime).Seconds())

--- a/config.yaml
+++ b/config.yaml
@@ -12,10 +12,6 @@ bearerAuth:
   active: false
   signingKey: my_secret_key
 
-timeouts:
-  max_timeout: 0
-  enforced: false
-
 scripts:
   - name: test
     script: ./examples/test.sh

--- a/config.yaml
+++ b/config.yaml
@@ -12,6 +12,9 @@ bearerAuth:
   active: false
   signingKey: my_secret_key
 
+timeouts:
+  max_timeout: 0
+
 scripts:
   - name: test
     script: ./examples/test.sh
@@ -21,3 +24,7 @@ scripts:
     script: ./examples/helloworld.sh test
   - name: curltest
     script: ./bin/curltest
+  - name: showtimeout
+    script: ./examples/showtimeout.sh
+    timeout:
+      max_timeout: 60

--- a/config.yaml
+++ b/config.yaml
@@ -14,6 +14,7 @@ bearerAuth:
 
 timeouts:
   max_timeout: 0
+  enforced: false
 
 scripts:
   - name: test
@@ -28,3 +29,7 @@ scripts:
     script: ./examples/showtimeout.sh
     timeout:
       max_timeout: 60
+  - name: sleep
+    script: sleep 120
+    timeout:
+      enforced: true

--- a/examples/showtimeout.sh
+++ b/examples/showtimeout.sh
@@ -1,0 +1,17 @@
+#!/bin/sh
+echo "# HELP script_has_timeout Whether this script is run with a timeout."
+echo "# TYPE script_has_timeout gauge"
+if [ -z "$SCRIPT_TIMEOUT" ]; then
+	echo "script_has_timeout{} 0"
+	exit 0
+fi
+echo "script_has_timeout{} 1"
+
+echo "# HELP script_timeout_seconds Timeout of the script in seconds"
+echo "# TYPE script_timeout_seconds gauge"
+echo "script_timeout_seconds{} $SCRIPT_TIMEOUT"
+
+echo "# HELP script_deadline_seconds Unix timestamp when the timeout will expire"
+echo "# TYPE script_deadline_seconds gauge"
+echo "script_deadline_seconds{} $SCRIPT_DEADLINE"
+exit 0

--- a/examples/showtimeout.sh
+++ b/examples/showtimeout.sh
@@ -14,4 +14,8 @@ echo "script_timeout_seconds{} $SCRIPT_TIMEOUT"
 echo "# HELP script_deadline_seconds Unix timestamp when the timeout will expire"
 echo "# TYPE script_deadline_seconds gauge"
 echo "script_deadline_seconds{} $SCRIPT_DEADLINE"
+
+echo "# HELP script_timeout_enforced Whether or not script_exporter is enforcing a timeout on the script."
+echo "# TYPE script_timeout_enforced gauge"
+echo "script_timeout_enforced{} $SCRIPT_TIMEOUT_ENFORCED"
 exit 0

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -33,8 +33,6 @@ type Config struct {
 		SigningKey string `yaml:"signingKey"`
 	} `yaml:"bearerAuth"`
 
-	Timeouts timeout `yaml:"timeouts"`
-
 	Scripts []struct {
 		Name    string `yaml:"name"`
 		Script  string `yaml:"script"`
@@ -68,9 +66,7 @@ func (c *Config) GetScript(scriptName string) string {
 	return ""
 }
 
-// GetMaxTimeout returns the max_timeout for a given script name,
-// which comes from either the script's specific setting (if set)
-// or the global setting.
+// GetMaxTimeout returns the max_timeout for a given script name.
 func (c *Config) GetMaxTimeout(scriptName string) float64 {
 	for _, script := range c.Scripts {
 		if script.Name == scriptName {
@@ -80,14 +76,11 @@ func (c *Config) GetMaxTimeout(scriptName string) float64 {
 			break
 		}
 	}
-	if c.Timeouts.MaxTimeout != nil {
-		return *c.Timeouts.MaxTimeout
-	}
 	return 0
 }
 
 // GetTimeoutEnforced returns whether or not timeouts should be
-// enforced by script_exporter for a particular script.
+// enforced by script_exporter for a particular script name.
 func (c *Config) GetTimeoutEnforced(scriptName string) bool {
 	for _, script := range c.Scripts {
 		if script.Name == scriptName {
@@ -96,9 +89,6 @@ func (c *Config) GetTimeoutEnforced(scriptName string) bool {
 			}
 			break
 		}
-	}
-	if c.Timeouts.Enforced != nil {
-		return *c.Timeouts.Enforced
 	}
 	return false
 }

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -8,8 +8,10 @@ import (
 
 // Making MaxTimeout a pointer to a float64 allows us to tell the
 // difference between an explicit 0 and an unconfigured setting.
+// Ditto for Enforced.
 type timeout struct {
 	MaxTimeout *float64 `yaml:"max_timeout"`
+	Enforced   *bool    `yaml:"enforced"`
 }
 
 // Config represents the structur of the configuration file
@@ -82,4 +84,21 @@ func (c *Config) GetMaxTimeout(scriptName string) float64 {
 		return *c.Timeouts.MaxTimeout
 	}
 	return 0
+}
+
+// GetTimeoutEnforced returns whether or not timeouts should be
+// enforced by script_exporter for a particular script.
+func (c *Config) GetTimeoutEnforced(scriptName string) bool {
+	for _, script := range c.Scripts {
+		if script.Name == scriptName {
+			if script.Timeout.Enforced != nil {
+				return *script.Timeout.Enforced
+			}
+			break
+		}
+	}
+	if c.Timeouts.Enforced != nil {
+		return *c.Timeouts.Enforced
+	}
+	return false
 }


### PR DESCRIPTION
When Prometheus scrapes a HTTP endpoint, it passes its timeout for that scrape in a special HTTP header. We now export the information from that timeout into environment variables, so that scripts can use it; copying what the Blackbox exporter does, by default we reduce the timeout slightly to account for overhead. On a per-script basis, you can also configure a maximum timeout for this (in case you know a script should fail faster than Prometheus's normal timeout) and also ask `script_exporter` to enforce the timeout by killing the main process if the timeout is reached. The default is no maximum timeout and no enforcement.

(The enforcement basically duplicates what you could do yourself by running scripts as `timeout $SCRIPT_TIMEOUT ...`.)

Closes #11