### PR TITLE
Prepare release 2.0.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,17 +54,17 @@ The configuration file is written in YAML format, defined by the scheme describe
 
 ```yaml
 tls:
-  active: <boolean>
+  enabled: <boolean>
   crt: <string>
   key: <string>
 
 basicAuth:
-  active: <boolean>
+  enabled: <boolean>
   username: <string>
   password: <string>
 
 bearerAuth:
-  active: <boolean>
+  enabled: <boolean>
   signingKey: <string>
 
 scripts:

--- a/cmd/script_exporter/auth.go
+++ b/cmd/script_exporter/auth.go
@@ -12,7 +12,7 @@ import (
 func auth(h http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		// Basic authentication
-		if exporterConfig.BasicAuth.Active {
+		if exporterConfig.BasicAuth.Enabled {
 			w.Header().Set("WWW-Authenticate", `Basic realm="Restricted"`)
 
 			username, password, authOK := r.BasicAuth()
@@ -28,7 +28,7 @@ func auth(h http.Handler) http.Handler {
 		}
 
 		// Authentication using bearer token
-		if exporterConfig.BearerAuth.Active {
+		if exporterConfig.BearerAuth.Enabled {
 			authHeader := r.Header.Get("Authorization")
 			if authHeader == "" {
 				http.Error(w, "Not authorized", http.StatusUnauthorized)

--- a/cmd/script_exporter/auth.go
+++ b/cmd/script_exporter/auth.go
@@ -9,16 +9,8 @@ import (
 	"github.com/dgrijalva/jwt-go"
 )
 
-func use(h http.HandlerFunc, middleware ...func(http.HandlerFunc) http.HandlerFunc) http.HandlerFunc {
-	for _, m := range middleware {
-		h = m(h)
-	}
-
-	return h
-}
-
-func auth(h http.HandlerFunc) http.HandlerFunc {
-	return func(w http.ResponseWriter, r *http.Request) {
+func auth(h http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		// Basic authentication
 		if exporterConfig.BasicAuth.Active {
 			w.Header().Set("WWW-Authenticate", `Basic realm="Restricted"`)
@@ -57,7 +49,7 @@ func auth(h http.HandlerFunc) http.HandlerFunc {
 		}
 
 		h.ServeHTTP(w, r)
-	}
+	})
 }
 
 // checkJWT validates jwt tokens

--- a/cmd/script_exporter/script_exporter.go
+++ b/cmd/script_exporter/script_exporter.go
@@ -403,12 +403,14 @@ func main() {
 		Handler: auth(router),
 	}
 
+	// Listen for SIGINT and SIGTERM signals and try to gracefully shutdown
+	// the HTTP server. This ensures that active connections are not
+	// interrupted.
 	go func() {
 		term := make(chan os.Signal, 1)
 		signal.Notify(term, os.Interrupt, syscall.SIGTERM)
 		select {
 		case <-term:
-			// Shutdown server
 			ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 			defer cancel()
 
@@ -423,6 +425,9 @@ func main() {
 		}
 	}()
 
+	// Listen for SIGHUP signal and reload the configuration. If the
+	// configuration could not be reloaded, the old config will continue to be
+	// used.
 	go func() {
 		hup := make(chan os.Signal, 1)
 		signal.Notify(hup, syscall.SIGHUP)

--- a/cmd/script_exporter/script_exporter.go
+++ b/cmd/script_exporter/script_exporter.go
@@ -404,7 +404,7 @@ func main() {
 	}
 
 	// Listen for SIGINT and SIGTERM signals and try to gracefully shutdown
-	// the HTTP server. This ensures that active connections are not
+	// the HTTP server. This ensures that enabled connections are not
 	// interrupted.
 	go func() {
 		term := make(chan os.Signal, 1)
@@ -442,7 +442,7 @@ func main() {
 		}
 	}()
 
-	if exporterConfig.TLS.Active {
+	if exporterConfig.TLS.Enabled {
 		log.Fatalln(server.ListenAndServeTLS(exporterConfig.TLS.Crt, exporterConfig.TLS.Key))
 	} else {
 		log.Fatalln(server.ListenAndServe())

--- a/cmd/script_exporter/script_exporter.go
+++ b/cmd/script_exporter/script_exporter.go
@@ -423,6 +423,20 @@ func main() {
 		}
 	}()
 
+	go func() {
+		hup := make(chan os.Signal, 1)
+		signal.Notify(hup, syscall.SIGHUP)
+		select {
+		case <-hup:
+			err := exporterConfig.LoadConfig(*configFile)
+			if err != nil {
+				log.Printf("Could not reload configuration: %s\n", err.Error())
+			} else {
+				log.Printf("Configuration reloaded\n")
+			}
+		}
+	}()
+
 	if exporterConfig.TLS.Active {
 		log.Fatalln(server.ListenAndServeTLS(exporterConfig.TLS.Crt, exporterConfig.TLS.Key))
 	} else {

--- a/config.yaml
+++ b/config.yaml
@@ -1,15 +1,15 @@
 tls:
-  active: false
+  enabled: false
   crt: server.crt
   key: server.key
 
 basicAuth:
-  active: false
+  enabled: false
   username: admin
   password: admin
 
 bearerAuth:
-  active: false
+  enabled: false
   signingKey: my_secret_key
 
 scripts:

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -17,19 +17,19 @@ type timeout struct {
 // Config represents the structur of the configuration file
 type Config struct {
 	TLS struct {
-		Active bool   `yaml:"active"`
-		Crt    string `yaml:"crt"`
-		Key    string `yaml:"key"`
+		Enabled bool   `yaml:"enabled"`
+		Crt     string `yaml:"crt"`
+		Key     string `yaml:"key"`
 	} `yaml:"tls"`
 
 	BasicAuth struct {
-		Active   bool   `yaml:"active"`
+		Enabled  bool   `yaml:"enabled"`
 		Username string `yaml:"username"`
 		Password string `yaml:"password"`
 	} `yaml:"basicAuth"`
 
 	BearerAuth struct {
-		Active     bool   `yaml:"active"`
+		Enabled    bool   `yaml:"enabled"`
 		SigningKey string `yaml:"signingKey"`
 	} `yaml:"bearerAuth"`
 


### PR DESCRIPTION
- Add authentication to all routes. Currently only the `/probe` route is protected. This behavior is changed to also protect the `/metrics` and `/` route, if authentication is enabled.
- Add graceful shutdown
- Add configuration reload
- Rename the `active` parameters in the configuration to `enabled`