### PR TITLE
Bump golang base image version to golang:1.17-alpine3.14

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.16-alpine3.14 as build
+FROM golang:1.17-alpine3.14 as build
 
 RUN apk add --no-cache --update git make
 


### PR DESCRIPTION
Reason:
* Fixes security vulnerabilities in golang:1.16-alpine3.14.


Output from `docker scan`:
```
$> docker scan ricoberger/script_exporter:v2.3.0

Testing ricoberger/script_exporter:v2.3.0...

✗ High severity vulnerability found in openssl/libcrypto1.1
  Description: Buffer Overflow
  Info: https://snyk.io/vuln/SNYK-ALPINE314-OPENSSL-1569445
  Introduced through: openssl/libcrypto1.1@1.1.1k-r0, openssl/libssl1.1@1.1.1k-r0, apk-tools/apk-tools@2.12.7-r0, libretls/libretls@3.3.3p1-r2, ca-certificates/ca-certificates@20191127-r5, curl/libcurl@7.78.0-r0
  From: openssl/libcrypto1.1@1.1.1k-r0
  From: openssl/libssl1.1@1.1.1k-r0 > openssl/libcrypto1.1@1.1.1k-r0
  From: apk-tools/apk-tools@2.12.7-r0 > openssl/libcrypto1.1@1.1.1k-r0
  and 7 more...
  Image layer: 'RUN /bin/sh -c apk add --no-cache --update curl ca-certificates '
  Fixed in: 1.1.1l-r0

✗ High severity vulnerability found in openssl/libcrypto1.1
  Description: Out-of-bounds Read
  Info: https://snyk.io/vuln/SNYK-ALPINE314-OPENSSL-1569449
  Introduced through: openssl/libcrypto1.1@1.1.1k-r0, openssl/libssl1.1@1.1.1k-r0, apk-tools/apk-tools@2.12.7-r0, libretls/libretls@3.3.3p1-r2, ca-certificates/ca-certificates@20191127-r5, curl/libcurl@7.78.0-r0
  From: openssl/libcrypto1.1@1.1.1k-r0
  From: openssl/libssl1.1@1.1.1k-r0 > openssl/libcrypto1.1@1.1.1k-r0
  From: apk-tools/apk-tools@2.12.7-r0 > openssl/libcrypto1.1@1.1.1k-r0
  and 7 more...
  Image layer: 'RUN /bin/sh -c apk add --no-cache --update curl ca-certificates '
  Fixed in: 1.1.1l-r0



Package manager:   apk
Project name:      docker-image|ricoberger/script_exporter
Docker image:      ricoberger/script_exporter:v2.3.0
Platform:          linux/amd64
Base image:        alpine:3.14.1

Tested 19 dependencies for known vulnerabilities, found 2 vulnerabilities.

Base Image     Vulnerabilities  Severity
alpine:3.14.1  2                2 high, 0 medium, 0 low

Recommendations for base image upgrade:

Minor upgrades
Base Image     Vulnerabilities  Severity
alpine:3.14.2  0                0 high, 0 medium, 0 low
```


After rebuilding on golang1.17-alpine3.14 image:
```
$> docker scan thecosmicfrog/script_exporter:latest

Testing thecosmicfrog/script_exporter:latest...

Package manager:   apk
Project name:      docker-image|thecosmicfrog/script_exporter
Docker image:      thecosmicfrog/script_exporter:latest
Platform:          linux/amd64
Base image:        alpine:3.14.2

✓ Tested 19 dependencies for known vulnerabilities, no vulnerable paths found.

According to our scan, you are currently using the most secure version of the selected base image
```

This is a really useful Docker image - so just contributing to keep it up-to-date. Thanks!
Aaron