### PR TITLE
Add example for script arguments

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ Then visit [http://localhost:9469](http://localhost:9469) in the browser of your
 - [helloworld](http://localhost:9469/probe?script=helloworld): Returns the specified argument in the `script` as label.
 - [showtimeout](http://localhost:9469/probe?script=showtimeout&timeout=37): Reports whether or not the script is being run with a timeout from Prometheus, and what it is.
 - [docker](http://localhost:9469/probe?script=docker): Example using `docker exec` to return the number of files in a Docker container.
+- [args](http://localhost:9469/probe?script=args&params=arg3,arg4&arg3=test3&arg4=test4): Pass arguments to the script via the configuration file.
 - [metrics](http://localhost:9469/metrics): Shows internal metrics from the script exporter.
 
 You can also deploy the script_exporter to Kubernetes. An example Deployment file can be found here: [examples/kubernetes.yaml](./examples/kubernetes.yaml).

--- a/examples/args.sh
+++ b/examples/args.sh
@@ -1,0 +1,14 @@
+#! /bin/bash
+
+# scrape_configs:
+#   - job_name: 'script_args'
+#     metrics_path: /probe
+#     params:
+#       script: [args]
+#       params: ["arg3,arg4"]
+#       arg3: [test3]
+#       arg4: [test4]
+#     static_configs:
+#       - targets: ["localhost:9469"]
+
+echo "script_with_arguments{arg1=\"$1\", arg2=\"$2\", arg3=\"$3\", arg4=\"$4\"} 1"

--- a/examples/config.yaml
+++ b/examples/config.yaml
@@ -29,3 +29,5 @@ scripts:
       enforced: true
   - name: docker
     script: ./examples/docker.sh
+  - name: args
+    script: ./examples/args.sh test1 test2


### PR DESCRIPTION
This commit adds a new example, which shows the usage of arguments
passed in the script configuration and via the "params" property.