### PR TITLE
Fix example configuration

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -5,7 +5,7 @@ services:
       - '-config.file=/bin/examples/config.yaml'
       - '-web.listen-address=:9469'
     container_name: 'script_exporter'
-    image: 'ricoberger/script_exporter:v2.4.0'
+    image: 'ricoberger/script_exporter:v2.5.2'
     ports:
       - '9469:9469'
     volumes:

--- a/examples/config.yaml
+++ b/examples/config.yaml
@@ -19,13 +19,13 @@ discovery:
 
 scripts:
   - name: test
-    script: ./examples/test.sh
+    script: sh /bin/examples/test.sh
   - name: ping
-    script: ./examples/ping.sh
+    script: sh /bin/examples/ping.sh
   - name: helloworld
-    script: ./examples/helloworld.sh test
+    script: sh /bin/examples/helloworld.sh test
   - name: showtimeout
-    script: ./examples/showtimeout.sh
+    script: sh /bin/examples/showtimeout.sh
     timeout:
       max_timeout: 60
   - name: sleep
@@ -33,6 +33,6 @@ scripts:
     timeout:
       enforced: true
   - name: docker
-    script: ./examples/docker.sh
+    script: sh /bin/examples/docker.sh
   - name: args
-    script: ./examples/args.sh test1 test2
+    script: sh /bin/examples/args.sh test1 test2


### PR DESCRIPTION
## Problem
By default, the example configuration does not work.
We have observed this behavior with the official [Docker image](https://hub.docker.com/r/ricoberger/script_exporter) and by manually building the Docker image.

## Solution
Using absolute paths and adding `sh` to the beginning of each command resolves the problem.
Furthermore, the `docker-compose.yml` uses a Docker image version that is one year old (`2.4.0`). I replaced this with the latest version (`2.5.2`).