### PR TITLE
Define script parameters in config as array

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -58,6 +58,10 @@ Temporary Items
 # Output of the go coverage tool, specifically when used with LiteIDE
 *.out
 
+################################
+########### Jetbrains ##########
+################################
+.idea/
 
 ################################
 ############ Custom ############

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -1,0 +1,203 @@
+package config
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestConfigValidation(t *testing.T) {
+	type testCase struct {
+		config         Config
+		expectedErrors int
+		description    string
+	}
+	testCases := []testCase{
+		{
+			config: Config{
+				Scripts: []ScriptConfig{
+					{
+						Name:   "unittest",
+						Script: "unit test script",
+					},
+				},
+			},
+			expectedErrors: 0,
+			description:    "Valid config with script",
+		},
+		{
+			config: Config{
+				Scripts: []ScriptConfig{
+					{
+						Name:    "unittest",
+						Command: "unit test command",
+					},
+				},
+			},
+			expectedErrors: 0,
+			description:    "Valid config with command",
+		},
+		{
+			config: Config{
+				Scripts: []ScriptConfig{
+					{
+						Name:    "unittest",
+						Command: "unit test command",
+						Args:    []string{"arg1", "arg2"},
+					},
+				},
+			},
+			expectedErrors: 0,
+			description:    "Valid config with command + args",
+		},
+		{
+			config: Config{
+				Scripts: []ScriptConfig{
+					{
+						Name:    "unittest",
+						Script:  "unit test script",
+						Command: "unit test command",
+						Args:    []string{"arg1", "arg2"},
+					},
+				},
+			},
+			expectedErrors: 1,
+			description:    "script + args + command is rejected",
+		},
+		{
+			config: Config{
+				Scripts: []ScriptConfig{
+					{
+						Name:    "unittest",
+						Script:  "unit test script",
+						Command: "unit test command",
+					},
+				},
+			},
+			expectedErrors: 1,
+			description:    "script + command is rejected",
+		},
+		{
+			config: Config{
+				Scripts: []ScriptConfig{
+					{
+						Name:   "unittest",
+						Script: "unit test script",
+						Args:   []string{"arg1", "arg2"},
+					},
+				},
+			},
+			expectedErrors: 1,
+			description:    "script + args is rejected",
+		},
+		{
+			config: Config{
+				Scripts: []ScriptConfig{
+					{
+						Name:    "unittest1",
+						Script:  "unit test script",
+						Command: "unit test command",
+						Args:    []string{"arg1", "arg2"},
+					},
+					{
+						Name:    "unittest2",
+						Script:  "unit test script",
+						Command: "unit test command",
+						Args:    []string{"arg1", "arg2"},
+					},
+				},
+			},
+			expectedErrors: 2,
+			description:    "script + command + args is rejected, multiple times",
+		},
+		{
+			config: Config{
+				Scripts: []ScriptConfig{
+					{
+						Name: "unittest1",
+						Args: []string{"arg1", "arg2"},
+					},
+				},
+			},
+			expectedErrors: 1,
+			description:    "Neither script nor command",
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.description, func(t *testing.T) {
+			errs := ValidateConfig(&tc.config)
+			if len(errs) != tc.expectedErrors {
+				t.Errorf("Expected %d errors, got %d", tc.expectedErrors, len(errs))
+			}
+		})
+	}
+}
+
+func TestConfig_GetRunArgs(t *testing.T) {
+	type testCase struct {
+		config      Config
+		expected    []string
+		err         bool
+		description string
+	}
+	scriptName := "unittest"
+	testCases := []testCase{
+		{
+			config: Config{
+				Scripts: []ScriptConfig{
+					{
+						Name:   scriptName,
+						Script: "script a b",
+					},
+				},
+			},
+			expected:    []string{"script", "a", "b"},
+			description: "Valid config with script",
+		},
+		{
+			config: Config{
+				Scripts: []ScriptConfig{
+					{
+						Name:    scriptName,
+						Command: "test command",
+					},
+				},
+			},
+			expected:    []string{"test command"},
+			description: "Valid config with command",
+		},
+		{
+			config: Config{
+				Scripts: []ScriptConfig{
+					{
+						Name:    scriptName,
+						Command: "test command",
+						Args:    []string{"arg1", "arg2"},
+					},
+				},
+			},
+			expected:    []string{"test command", "arg1", "arg2"},
+			description: "Valid config with command and args",
+		},
+		{
+			config: Config{
+				Scripts: []ScriptConfig{},
+			},
+			err:         true,
+			description: "Missing script",
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.description, func(t *testing.T) {
+			runArgs, err := GetRunArgs(&tc.config, scriptName)
+			if err != nil && !tc.err {
+				t.Errorf("Got unexpected error %v", err)
+			}
+			if err == nil && tc.err {
+				t.Error("Expected error")
+			}
+			if !reflect.DeepEqual(tc.expected, runArgs) {
+				t.Errorf("Expected runArgs %v, got %v", tc.expected, runArgs)
+			}
+		})
+	}
+}

--- a/pkg/exporter/exporter.go
+++ b/pkg/exporter/exporter.go
@@ -50,6 +50,15 @@ func NewExporter(configFile string, createToken bool, timeoutOffset float64, noa
 		log.Fatalln(err)
 	}
 
+	// Validate configuration
+	errs := config.ValidateConfig(e.Config)
+	if len(errs) > 0 {
+		for _, err := range errs {
+			log.Printf("Miconfiguration detected: %s", err)
+		}
+		log.Fatalln("Invalid configuration")
+	}
+
 	// Create bearer token
 	if createToken {
 		token, err := auth.CreateJWT(*e.Config)


### PR DESCRIPTION
Motivation: https://github.com/ricoberger/script_exporter/issues/55

Fixes https://github.com/ricoberger/script_exporter/issues/55, https://github.com/ricoberger/script_exporter/issues/51

@ricoberger Feel free to take a look at the implementation already. I still need to update README, examples, etc.

Example output for invalid configuration:
```
2022/09/06 14:19:01 Miconfiguration detected: script config ping combines mutually exclusive settings 'script' and 'command' / 'args'
2022/09/06 14:19:01 Miconfiguration detected: script config ping2 combines mutually exclusive settings 'script' and 'command' / 'args'
2022/09/06 14:19:01 Miconfiguration detected: script config helloworld has neither 'script' nor 'command'
2022/09/06 14:19:01 Invalid configuration
```