### PR TITLE
Fix the way to detect if running as Windows service

### DIFF
--- a/cmd/script_exporter/script_exporter_windows.go
+++ b/cmd/script_exporter/script_exporter_windows.go
@@ -19,14 +19,14 @@ import (
 func main() {
 	e := exporter.InitExporter()
 
-	isInteractive, err := svc.IsAnInteractiveSession()
+	isService, err := svc.IsWindowsService()
 	if err != nil {
 		level.Error(e.Logger).Log("err", err)
 		os.Exit(1)
 	}
 
 	stopCh := make(chan bool)
-	if !isInteractive {
+	if isService {
 		go func() {
 			err = svc.Run("Script Exporter", win.NewWindowsExporterService(stopCh))
 			if err != nil {


### PR DESCRIPTION
The function https://pkg.go.dev/golang.org/x/sys/windows/svc#IsAnInteractiveSession is deprecated because the way to detect if it's a service or not is not reliable.
So I fixed to use `IsWindowsService` instead of `IsAnInteractiveSession`.

With this change, if you wrap your service with NSSM (or WinSW), script_exporter will now be correctly detected as a non-service and will be able to start as wrapped service.
Fixes #47 