### PR TITLE
Adding prefix path option to discovery

### DIFF
--- a/examples/config.yaml
+++ b/examples/config.yaml
@@ -16,6 +16,7 @@ discovery:
   # host: localhost
   # port: 1231
   # scheme: https
+  # path: /prefix-path
 
 scripts:
   - name: test

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -42,6 +42,7 @@ type Config struct {
 		Host   string `yaml:"host"`
 		Port   string `yaml:"port"`
 		Scheme string `yaml:"scheme"`
+		Path   string `yaml:"path"`
 	} `yaml:"discovery"`
 }
 

--- a/pkg/exporter/exporter.go
+++ b/pkg/exporter/exporter.go
@@ -143,6 +143,7 @@ func InitExporter() (e *Exporter) {
 			port = "9469"
 		}
 		scheme := "http"
+		path   := ""
 		if len(e.Config.Discovery.Host) > 0 {
 			host = e.Config.Discovery.Host
 		}
@@ -152,11 +153,14 @@ func InitExporter() (e *Exporter) {
 		if len(e.Config.Discovery.Scheme) > 0 {
 			scheme = e.Config.Discovery.Scheme
 		}
+		if len(e.Config.Discovery.Path) > 0 {
+			path = e.Config.Discovery.Path
+		}
 		w.Header().Set("Content-Type", "application/json")
 		w.Write([]byte(`[ `))
 		for idx, script := range e.Config.Scripts {
 			w.Write([]byte(`{"targets": ["` + host + `:` + port + `"],`))
-			w.Write([]byte(`"labels":{"__scheme__":"` + scheme + `","__metrics_path__":"/probe","__param_script":"` + script.Name + `"}}`))
+			w.Write([]byte(`"labels":{"__scheme__":"` + scheme + `","__metrics_path__":"` + path + `/probe","__param_script":"` + script.Name + `"}}`))
 			if idx+1 < len(e.Config.Scripts) {
 				w.Write([]byte(`,`))
 			}


### PR DESCRIPTION
Hi, thanks for the nice project.

I hit an issue, because I'm running the exporter behind a reverse-proxy.

Example
```
myhost/script_exporter   -> localhost:9469
myhost/node_exporter     -> localhost:9100
```

When I call myhost/script_exporter/discovery the response loses the context of /script_exporter and responds with 

```
[
    {
        "targets": [
            myhost:443"
        ],
        "labels": {
            "__scheme__": "http",
            "__metrics_path__": "/probe",
            "__param_script": "pg-auto-failover"
        }
    }
]
```

After the PR...

An edit to `/config.yaml` like:

```
discovery:
  path: "/script_exporter"
```

Returns

`... "__metrics_path__": "/script_exporter/probe" ...`

Please consider reviewing / merging. I'm no go developer, so there will be room to improve this PR.

Thanks :)