### PR TITLE
:warning: Parse Output when Script Fails

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,9 @@ scripts:
     # optional
     env:
       <key>: <value>
+    # by default the output will also be parsed when the script fails,
+    # this can be changed by setting this option to true
+    ignoreOutputOnFail: <boolean>
     timeout:
       # in seconds, 0 or negative means none
       max_timeout: <float>

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -48,12 +48,13 @@ type Config struct {
 
 // ScriptConfig is the configuration for a single script.
 type ScriptConfig struct {
-	Name    string   `yaml:"name"`
-	Script  string   `yaml:"script"`
-	Command string   `yaml:"command"`
-	Args    []string `yaml:"args"`
-	Env     []string `yaml:"env"`
-	Timeout timeout
+	Name               string   `yaml:"name"`
+	Script             string   `yaml:"script"`
+	Command            string   `yaml:"command"`
+	Args               []string `yaml:"args"`
+	Env                []string `yaml:"env"`
+	IgnoreOutputOnFail bool     `yaml:"ignoreOutputOnFail"`
+	Timeout            timeout
 }
 
 // LoadConfig reads the configuration file and umarshal the data into the config struct
@@ -117,6 +118,16 @@ func (c *Config) GetRunEnv(scriptName string) []string {
 		}
 	}
 	return nil
+}
+
+// GetIgnoreOutputOnFail returns the ignoreOutputOnFail parameter for the provided script.
+func (c *Config) GetIgnoreOutputOnFail(scriptName string) bool {
+	for _, script := range c.Scripts {
+		if script.Name == scriptName {
+			return script.IgnoreOutputOnFail
+		}
+	}
+	return false
 }
 
 // GetMaxTimeout returns the max_timeout for a given script name.

--- a/pkg/exporter/scripts.go
+++ b/pkg/exporter/scripts.go
@@ -91,10 +91,10 @@ func runScript(name string, logger log.Logger, timeout float64, enforced bool, a
 			"err", err,
 		)
 		if exitError, ok := err.(*exec.ExitError); ok {
-			return "", exitError.ExitCode(), err
+			return stdout.String(), exitError.ExitCode(), err
 		}
 
-		return "", -1, err
+		return stdout.String(), -1, err
 	}
 
 	level.Debug(logger).Log(


### PR DESCRIPTION
Until now, we just ignored the output of the script when the script failed. Now we are also parsing the output when the script failed. To get the old bahaviour the "ignoreOutputOnFail" property in the script settings can be set to "true".

Closes #67
Closes #63