### PR TITLE
fix: Added missing part to setup environment 

### DIFF
--- a/charts/script-exporter/Chart.yaml
+++ b/charts/script-exporter/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: script-exporter
 description: Prometheus exporter to execute scripts and collect metrics from the output or the exit status.
 type: application
-version: 0.6.0
+version: 0.6.1
 appVersion: v2.12.0

--- a/charts/script-exporter/templates/deployment.yaml
+++ b/charts/script-exporter/templates/deployment.yaml
@@ -30,6 +30,8 @@ spec:
             {{- toYaml .Values.securityContext | nindent 12 }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
+          env:
+          {{- toYaml .Values.env | nindent 10 }}
           args:
             - -config.file=/etc/script-exporter/config.yaml
           ports:

--- a/charts/script-exporter/templates/deployment.yaml
+++ b/charts/script-exporter/templates/deployment.yaml
@@ -30,8 +30,10 @@ spec:
             {{- toYaml .Values.securityContext | nindent 12 }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
+          {{- with .Values.env }}
           env:
-          {{- toYaml .Values.env | nindent 10 }}
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           args:
             - -config.file=/etc/script-exporter/config.yaml
           ports:


### PR DESCRIPTION
Hello Maintainers,

Being able to add custom environment variables to script exporter opens up a lot of opportunities to maintain and do more integrations. I am using this feature to be able to add custom params to my scripts se example 

values.yaml 
```
config: |
  tls:
    enabled: false

  basicAuth:
    enabled: false

  bearerAuth:
    enabled: false

  scripts:
  - name: testing_script
    command: /usr/bin/env
    args:
    - bash
    - -xc
    - |
      echo '# HELP request_time Total time spent making performing the curl'
      echo '# TYPE request_time gauge'
      curl -ILsk \
        --user "${MY_USERNAME}:${MY_PASSWORD}" \
        -w '%{time_total}' \
        -o /dev/null \
        ${URL} | xargs echo "request_time{script=\"testing_script\"}"


```

custom-params.yaml
```
env:
- name: URL
  value: 'https://internal.local'
- name: MY_USERNAME
  value: "integration-agent"
- name: MY_PASSWORD
  value: "example"

``` 

