### PR TITLE
:warning: Fix Environment Variable Handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ scripts:
 
 The `name` of the script must be a valid Prometheus label value. The `command` string is the script which is executed with all arguments specified in `args`. To add dynamic arguments you can pass the `params` query parameter with a list of query parameters which values should be added as argument. The program will be executed directly, without a shell being invoked, and it is recommended that it be specified by path instead of relying on ``$PATH``.
 
-The optional `env` hash allow to run the script with custom environment variables.
+The optional `env` key allows to run the script with custom environment variables.
 
 Example: set proxy env vars for test_env script
 

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -48,12 +48,12 @@ type Config struct {
 
 // ScriptConfig is the configuration for a single script.
 type ScriptConfig struct {
-	Name               string   `yaml:"name"`
-	Script             string   `yaml:"script"`
-	Command            string   `yaml:"command"`
-	Args               []string `yaml:"args"`
-	Env                []string `yaml:"env"`
-	IgnoreOutputOnFail bool     `yaml:"ignoreOutputOnFail"`
+	Name               string            `yaml:"name"`
+	Script             string            `yaml:"script"`
+	Command            string            `yaml:"command"`
+	Args               []string          `yaml:"args"`
+	Env                map[string]string `yaml:"env"`
+	IgnoreOutputOnFail bool              `yaml:"ignoreOutputOnFail"`
 	Timeout            timeout
 }
 
@@ -108,7 +108,7 @@ func GetRunArgs(c *Config, scriptName string) ([]string, error) {
 }
 
 // GetRunEnv returns the env variables for a given script name.
-func (c *Config) GetRunEnv(scriptName string) []string {
+func (c *Config) GetRunEnv(scriptName string) map[string]string {
 	for _, script := range c.Scripts {
 		if script.Name == scriptName {
 			if len(script.Env) > 0 {

--- a/pkg/exporter/scripts.go
+++ b/pkg/exporter/scripts.go
@@ -36,7 +36,7 @@ import (
 // be subject to abrupt termination regardless of any 'enforced:'
 // settings. Right now, abrupt termination requires opting in in
 // the configuration file.
-func runScript(name string, logger log.Logger, timeout float64, enforced bool, args []string, env []string) (string, int, error) {
+func runScript(name string, logger log.Logger, timeout float64, enforced bool, args []string, env map[string]string) (string, int, error) {
 	// We go through a great deal of work to get a deadline with
 	// fractional seconds that we can expose in an environment
 	// variable. However, this is pretty much necessary since
@@ -59,8 +59,8 @@ func runScript(name string, logger log.Logger, timeout float64, enforced bool, a
 
 	// Set environments variables
 	cmd.Env = os.Environ()
-	if len(env) > 0 {
-		cmd.Env = append(cmd.Env, env...)
+	for key, value := range env {
+		cmd.Env = append(cmd.Env, fmt.Sprintf("%s=%s", key, value))
 	}
 
 	if timeout > 0 {


### PR DESCRIPTION
In the readme we had an example on how to use the environment variables via key value pairs, but in the code we had it implemented as slice.

To fix this and because I prefer the key value pairs the code was adjusted to use a "map[string]string" instead of a slice of strings to specify the environment variables.

Fixes #80 