### PR TITLE
Add Cache Option

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,7 @@ scripts:
       # in seconds, 0 or negative means none
       max_timeout: <float>
       enforced: <boolean>
+    cacheDuration: <duration>
 ```
 
 The `name` of the script must be a valid Prometheus label value. The `command` string is the script which is executed with all arguments specified in `args`. To add dynamic arguments you can pass the `params` query parameter with a list of query parameters which values should be added as argument. The program will be executed directly, without a shell being invoked, and it is recommended that it be specified by path instead of relying on ``$PATH``.
@@ -135,9 +136,11 @@ For example:
 
 Prometheus will normally provide an indication of its scrape timeout to the script exporter (through a special HTTP header). This information is made available to scripts through the environment variables `$SCRIPT_TIMEOUT` and `$SCRIPT_DEADLINE`. The first is the timeout in seconds (including a fractional part) and the second is the Unix timestamp when the deadline will expire (also including a fractional part). A simple script could implement this timeout by starting with `timeout "$SCRIPT_TIMEOUT" cmd ...`. A more sophisticated program might want to use the deadline time to compute internal timeouts for various operation. If `enforced` is true, `script_exporter` attempts to enforce the timeout by killing the script's main process after the timeout expires. The default is to not enforce timeouts. If `max_timeout` is set for a script, it limits the maximum timeout value that requests can specify; a request that specifies a larger timeout will have the timeout adjusted down to the `max_timeout` value.
 
-The `discovery` configures the discovery parameters. If not defined, the exporter will use `Host:` header from the request to decide how to present a `target` to prometheus.
-
 For testing purposes, the timeout can be specified directly as a URL parameter (`timeout`). If present, the URL parameter takes priority over the Prometheus HTTP header.
+
+The `cacheDuration` config can be used to cache the results from an execution of the script for the provided time. The provided duration must be parsable by the [`time.ParseDuration`](https://pkg.go.dev/time#ParseDuration) function. If no cache duration is provided or the provided cache duration can not be parsed, the output of an script will not be cached.
+
+The `discovery` configures the discovery parameters. If not defined, the exporter will use `Host:` header from the request to decide how to present a `target` to prometheus.
 
 ## Prometheus configuration
 

--- a/examples/config.yaml
+++ b/examples/config.yaml
@@ -23,6 +23,7 @@ scripts:
     command: ./examples/test.sh
   - name: ping
     command: ./examples/ping.sh
+    cacheDuration: 1m
   - name: helloworld
     command: ./examples/helloworld.sh
     args:

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -188,7 +188,7 @@ func TestConfig_GetRunArgs(t *testing.T) {
 	}
 	for _, tc := range testCases {
 		t.Run(tc.description, func(t *testing.T) {
-			runArgs, err := GetRunArgs(&tc.config, scriptName)
+			runArgs, err := tc.config.GetRunArgs(scriptName)
 			if err != nil && !tc.err {
 				t.Errorf("Got unexpected error %v", err)
 			}

--- a/pkg/exporter/cache.go
+++ b/pkg/exporter/cache.go
@@ -1,0 +1,37 @@
+package exporter
+
+import (
+	"time"
+)
+
+var cache map[string]cacheEntry
+
+type cacheEntry struct {
+	cacheTime       time.Time
+	formattedOutput string
+	exitCode        int
+	successStatus   int
+}
+
+func getCacheResult(scriptName string, cacheDuration time.Duration) (*string, *int, *int) {
+	if entry, ok := cache[scriptName]; ok {
+		if entry.cacheTime.Add(cacheDuration).After(time.Now()) {
+			return &entry.formattedOutput, &entry.successStatus, &entry.exitCode
+		}
+	}
+
+	return nil, nil, nil
+}
+
+func setCacheResult(scriptName, formattedOutput string, successStatus, exitCode int) {
+	if cache == nil {
+		cache = make(map[string]cacheEntry)
+	}
+
+	cache[scriptName] = cacheEntry{
+		cacheTime:       time.Now(),
+		formattedOutput: formattedOutput,
+		exitCode:        exitCode,
+		successStatus:   successStatus,
+	}
+}


### PR DESCRIPTION
It is now possible to cache the output of an script via the newly added "cacheDuration" option. If this option is provided the exporter will return the output from the cache instead of executing the script again as long as the output is not stale.

If no cache duration is provided or if the provided cache duration can not be parsed, the output of a script will not be cached.

Closes #84