### PR TITLE
Include Params in Cache Key

### DIFF
--- a/pkg/exporter/cache.go
+++ b/pkg/exporter/cache.go
@@ -1,6 +1,8 @@
 package exporter
 
 import (
+	"fmt"
+	"strings"
 	"time"
 )
 
@@ -13,8 +15,8 @@ type cacheEntry struct {
 	successStatus   int
 }
 
-func getCacheResult(scriptName string, cacheDuration time.Duration) (*string, *int, *int) {
-	if entry, ok := cache[scriptName]; ok {
+func getCacheResult(scriptName string, paramValues []string, cacheDuration time.Duration) (*string, *int, *int) {
+	if entry, ok := cache[fmt.Sprintf("%s--%s", scriptName, strings.Join(paramValues, "-"))]; ok {
 		if entry.cacheTime.Add(cacheDuration).After(time.Now()) {
 			return &entry.formattedOutput, &entry.successStatus, &entry.exitCode
 		}
@@ -23,12 +25,12 @@ func getCacheResult(scriptName string, cacheDuration time.Duration) (*string, *i
 	return nil, nil, nil
 }
 
-func setCacheResult(scriptName, formattedOutput string, successStatus, exitCode int) {
+func setCacheResult(scriptName string, paramValues []string, formattedOutput string, successStatus, exitCode int) {
 	if cache == nil {
 		cache = make(map[string]cacheEntry)
 	}
 
-	cache[scriptName] = cacheEntry{
+	cache[fmt.Sprintf("%s--%s", scriptName, strings.Join(paramValues, "-"))] = cacheEntry{
 		cacheTime:       time.Now(),
 		formattedOutput: formattedOutput,
 		exitCode:        exitCode,

--- a/pkg/exporter/metrics.go
+++ b/pkg/exporter/metrics.go
@@ -52,7 +52,7 @@ func (e *Exporter) MetricsHandler(w http.ResponseWriter, r *http.Request) {
 	// stale.
 	cacheDuration := e.Config.GetCacheDuration(scriptName)
 	if cacheDuration != nil {
-		formattedOutput, successStatus, exitCode := getCacheResult(scriptName, *cacheDuration)
+		formattedOutput, successStatus, exitCode := getCacheResult(scriptName, paramValues, *cacheDuration)
 		if formattedOutput != nil && successStatus != nil && exitCode != nil {
 			level.Debug(e.Logger).Log("msg", "Returning cached result", "script", scriptName)
 			fmt.Fprintf(w, "%s\n%s\n%s_success{script=\"%s\"} %d\n%s\n%s\n%s_duration_seconds{script=\"%s\"} %f\n%s\n%s\n%s_exit_code{script=\"%s\"} %d\n%s\n", scriptSuccessHelp, scriptSuccessType, namespace, scriptName, *successStatus, scriptDurationSecondsHelp, scriptDurationSecondsType, namespace, scriptName, time.Since(scriptStartTime).Seconds(), scriptExitCodeHelp, scriptExitCodeType, namespace, scriptName, *exitCode, *formattedOutput)
@@ -131,7 +131,7 @@ func (e *Exporter) MetricsHandler(w http.ResponseWriter, r *http.Request) {
 	// later.
 	if cacheDuration != nil {
 		level.Debug(e.Logger).Log("msg", "Saving result to cache", "script", scriptName)
-		setCacheResult(scriptName, formattedOutput, successStatus, exitCode)
+		setCacheResult(scriptName, paramValues, formattedOutput, successStatus, exitCode)
 	}
 
 	fmt.Fprintf(w, "%s\n%s\n%s_success{script=\"%s\"} %d\n%s\n%s\n%s_duration_seconds{script=\"%s\"} %f\n%s\n%s\n%s_exit_code{script=\"%s\"} %d\n%s\n", scriptSuccessHelp, scriptSuccessType, namespace, scriptName, successStatus, scriptDurationSecondsHelp, scriptDurationSecondsType, namespace, scriptName, time.Since(scriptStartTime).Seconds(), scriptExitCodeHelp, scriptExitCodeType, namespace, scriptName, exitCode, formattedOutput)


### PR DESCRIPTION
Include the parameters which are passed to the script in the cache key, see https://github.com/ricoberger/script_exporter/issues/84#issuecomment-1692382237