### PR TITLE
Script discovery options

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,12 @@ scripts:
       max_timeout: <float>
       enforced: <boolean>
     cacheDuration: <duration>
+    discovery:
+      params:
+        <string>: <string>
+      prefix: <string>
+      scrape_interval: <duration>
+      scrape_timeout: <duration>
 ```
 
 The `name` of the script must be a valid Prometheus label value. The `command` string is the script which is executed with all arguments specified in `args`. To add dynamic arguments you can pass the `params` query parameter with a list of query parameters which values should be added as argument. The program will be executed directly, without a shell being invoked, and it is recommended that it be specified by path instead of relying on ``$PATH``.
@@ -140,7 +146,10 @@ For testing purposes, the timeout can be specified directly as a URL parameter (
 
 The `cacheDuration` config can be used to cache the results from an execution of the script for the provided time. The provided duration must be parsable by the [`time.ParseDuration`](https://pkg.go.dev/time#ParseDuration) function. If no cache duration is provided or the provided cache duration can not be parsed, the output of an script will not be cached.
 
-The `discovery` configures the discovery parameters. If not defined, the exporter will use `Host:` header from the request to decide how to present a `target` to prometheus.
+You can fine tune the script discovery options via optional script `discovery`. All these options will go through prometheus configuration where you can change them via relabel mechanism. 
+There are `params` to define dynamic script parameters (with reserved keys: `params`, `prefix`, `script` and `timeout`) where only value will be used during script invoking (similar to `args`), `prefix` to define prefix for all script metrics, `scrape_interval` to define how often the script scrape should run and `scrape_timeout` to define the scrape timeout for prometheus (similar to `timeout`).
+
+The global `discovery` configures the main discovery parameters. If not defined, the exporter will use `Host:` header from the request to decide how to present a `target` to prometheus.
 
 ## Prometheus configuration
 

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -121,6 +121,48 @@ func TestConfigValidation(t *testing.T) {
 			expectedErrors: 1,
 			description:    "Neither script nor command",
 		},
+		{
+			config: Config{
+				Scripts: []ScriptConfig{
+					{
+						Name:    "unittest",
+						Command: "unit test command",
+						Discovery: scriptDiscovery{
+							Params: map[string]string{
+								"key1": "value1",
+							},
+							Prefix:         "prefix",
+							ScrapeInterval: "1m",
+							ScrapeTimeout:  "1m",
+						},
+					},
+				},
+			},
+			expectedErrors: 0,
+			description:    "Valid config with script discovery",
+		},
+		{
+			config: Config{
+				Scripts: []ScriptConfig{
+					{
+						Name:    "unittest",
+						Command: "unit test command",
+						Discovery: scriptDiscovery{
+							Params: map[string]string{
+								"abc":     "value",
+								"params":  "value",
+								"prefix":  "value",
+								"script":  "value",
+								"test":    "value",
+								"timeout": "value",
+							},
+						},
+					},
+				},
+			},
+			expectedErrors: 4,
+			description:    "Invalid params names in script discovery",
+		},
 	}
 	for _, tc := range testCases {
 		t.Run(tc.description, func(t *testing.T) {


### PR DESCRIPTION
This PR adds ability to define more discovery options per script like dynamic parameters, prefix, scrape_interval and scrape_target. All of there parameters can be changed via prometheus relabeling.