### PR TITLE
Run container with `tini` as the init process.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ COPY . .
 RUN export CGO_ENABLED=0 && make build
 
 FROM alpine:3.18.2
-RUN apk add --no-cache --update bash curl jq ca-certificates
+RUN apk add --no-cache --update bash curl jq ca-certificates tini
 COPY --from=build /build/bin/script_exporter /bin/script_exporter
 EXPOSE 9469
-ENTRYPOINT  [ "/bin/script_exporter" ]
+ENTRYPOINT ["/sbin/tini", "--", "/bin/script_exporter"]


### PR DESCRIPTION
In some environments the container runtime does not act as an init process, leaving behind zombie processes. Using `tini` avoids that.

Fixes #92.