### PR TITLE
Allow Usage of ServiceAccount in Helm Chart

### DIFF
--- a/charts/script-exporter/Chart.yaml
+++ b/charts/script-exporter/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: script-exporter
 description: Prometheus exporter to execute scripts and collect metrics from the output or the exit status.
 type: application
-version: 0.6.5
+version: 0.7.0
 appVersion: v2.15.1

--- a/charts/script-exporter/templates/deployment.yaml
+++ b/charts/script-exporter/templates/deployment.yaml
@@ -22,6 +22,9 @@ spec:
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- if .Values.serviceAccount.name }}
+      serviceAccountName: "{{ .Values.serviceAccount.name }}"
+      {{- end }}
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
       containers:

--- a/charts/script-exporter/values.yaml
+++ b/charts/script-exporter/values.yaml
@@ -118,6 +118,9 @@ service:
   annotations: {}
   labels: {}
 
+serviceAccount:
+  name: ""
+
 ## Create a Service Monitor for the Prometheus Operator.
 ## See: https://github.com/coreos/prometheus-operator
 ##


### PR DESCRIPTION
It is now possible to provide the name of a ServiceAccount via the "serviceAccount.name" value in the Helm chart, which is then added to the Deployment of the script_exporter.

Closes #97