### PR TITLE
Allow Users to Run Multiple Scripts

### DIFF
--- a/pkg/exporter/scripts.go
+++ b/pkg/exporter/scripts.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"fmt"
 	"net/http"
+	"net/url"
 	"os"
 	"os/exec"
 	"strconv"
@@ -122,10 +123,10 @@ func runScript(name string, logger log.Logger, logEnv bool, timeout float64, enf
 // If the there is an error or no timeout is specified, it returns
 // the maxTimeout configured for the script (the default value for this
 // is 0, which means no timeout)
-func getTimeout(r *http.Request, offset float64, maxTimeout float64) float64 {
-	v := r.URL.Query().Get("timeout")
+func getTimeout(params url.Values, prometheusTimeout string, offset float64, maxTimeout float64) float64 {
+	v := params.Get("timeout")
 	if v == "" {
-		v = r.Header.Get("X-Prometheus-Scrape-Timeout-Seconds")
+		v = prometheusTimeout
 	}
 	if v == "" {
 		return maxTimeout


### PR DESCRIPTION
Until now it was only possible to run a single script within one Prometheus job, because the `script` parameter could only be provided one time.

With the changes in this commit it is now possible to run multiple scripts within one Prometheus job, for that the `script` parameter can be specified multiple times. For each specified script we are running the same logic as for a single script and then we merge the output of each script execution into one result.

Limitations:
- The specified parameters are used for all scripts, it is not possible to specifiy different parameters for the scripts.
- The timeout specified via the `X-Prometheus-Scrape-Timeout-Seconds` might not work correctly, if the offset is not large enough, since the timout logic is applied for all scripts.
- If there is an error in the logic for one script, e.g. one of the defined scripts can not be found, the other scripts will also return not output.

Closes #100 