### PR TITLE
[chart] Create a service monitor for each script

### DIFF
--- a/charts/script-exporter/Chart.yaml
+++ b/charts/script-exporter/Chart.yaml
@@ -3,4 +3,4 @@ name: script-exporter
 description: Prometheus exporter to execute scripts and collect metrics from the output or the exit status.
 type: application
 version: 0.8.0
-appVersion: v2.16.0
+appVersion: v2.17.0

--- a/charts/script-exporter/Chart.yaml
+++ b/charts/script-exporter/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: script-exporter
 description: Prometheus exporter to execute scripts and collect metrics from the output or the exit status.
 type: application
-version: 0.7.1
+version: 0.8.0
 appVersion: v2.16.0

--- a/charts/script-exporter/templates/selfservicemonitor.yaml
+++ b/charts/script-exporter/templates/selfservicemonitor.yaml
@@ -1,0 +1,36 @@
+{{- if .Values.serviceMonitor.selfMonitor.enabled }}
+---
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ include "script-exporter.fullname" . }}
+  labels:
+    {{- include "script-exporter.labels" . | nindent 4 }}
+    {{- include "script-exporter.serviceMonitorLabels" . | nindent 4 }}
+    namespace: {{ default .Release.Namespace .Values.serviceMonitor.namespace }}
+spec:
+  endpoints:
+    - port: http
+      {{- with .Values.serviceMonitor.interval }}
+      interval: {{ . }}
+      {{- end }}
+      {{- with .Values.serviceMonitor.scrapeTimeout }}
+      scrapeTimeout: {{ . }}
+      {{- end }}
+      path: /metrics
+      honorLabels: {{ .Values.serviceMonitor.honorLabels }}
+      {{- with .Values.serviceMonitor.metricRelabelings }}
+      metricRelabelings:
+      {{ toYaml . | nindent 6 }}
+      {{- end }}
+      {{- with .Values.serviceMonitor.relabelings }}
+      relabelings:
+      {{ toYaml . | nindent 6 }}
+      {{- end }}
+  namespaceSelector:
+    matchNames:
+      - {{ .Release.Namespace }}
+  selector:
+    matchLabels:
+      {{- include "script-exporter.selectorLabels" . | nindent 6 }}
+{{- end }}

--- a/charts/script-exporter/templates/servicemonitor.yaml
+++ b/charts/script-exporter/templates/servicemonitor.yaml
@@ -6,24 +6,25 @@ metadata:
   labels:
     {{- include "script-exporter.labels" . | nindent 4 }}
     {{- include "script-exporter.serviceMonitorLabels" . | nindent 4 }}
+    namespace: {{ default .Release.Namespace .Values.serviceMonitor.namespace }}
 spec:
   endpoints:
     - port: http
-      {{- if .Values.serviceMonitor.interval }}
-      interval: {{ .Values.serviceMonitor.interval }}
+      {{- with .Values.serviceMonitor.interval }}
+      interval: {{ . }}
       {{- end }}
-      {{- if .Values.serviceMonitor.scrapeTimeout }}
-      scrapeTimeout: {{ .Values.serviceMonitor.scrapeTimeout }}
+      {{- with .Values.serviceMonitor.scrapeTimeout }}
+      scrapeTimeout: {{ . }}
       {{- end }}
       path: /metrics
       honorLabels: {{ .Values.serviceMonitor.honorLabels }}
-      {{- if .Values.serviceMonitor.metricRelabelings }}
+      {{- with .Values.serviceMonitor.metricRelabelings }}
       metricRelabelings:
-      {{ toYaml .Values.serviceMonitor.metricRelabelings | nindent 6 }}
+      {{ toYaml . | nindent 6 }}
       {{- end }}
-      {{- if .Values.serviceMonitor.relabelings }}
+      {{- with .Values.serviceMonitor.relabelings }}
       relabelings:
-      {{ toYaml .Values.serviceMonitor.relabelings | nindent 6 }}
+      {{ toYaml . | nindent 6 }}
       {{- end }}
   namespaceSelector:
     matchNames:
@@ -31,4 +32,32 @@ spec:
   selector:
     matchLabels:
       {{- include "script-exporter.selectorLabels" . | nindent 6 }}
+{{- range (fromYaml .Values.config).scripts }}
+---
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  labels:
+    {{- include "script-exporter.labels" $ | nindent 4 }}
+    {{- include "script-exporter.serviceMonitorLabels" $ | nindent 4 }}
+  name: {{ include "script-exporter.fullname" $ }}-{{ kebabcase .name }}
+  namespace: {{ default $.Release.Namespace $.Values.serviceMonitor.namespace }}
+spec:
+  endpoints:
+    - path: /probe
+      port: http
+      params:
+        script:
+          - {{ .name }}
+      relabelings:
+        - action: replace
+          replacement: {{ .name }}
+          targetLabel: script
+  namespaceSelector:
+    matchNames:
+      - {{ $.Release.Namespace }}
+  selector:
+    matchLabels:
+      {{- include "script-exporter.selectorLabels" $ | nindent 6 }}
+{{- end }}
 {{- end -}}

--- a/charts/script-exporter/templates/servicemonitor.yaml
+++ b/charts/script-exporter/templates/servicemonitor.yaml
@@ -1,37 +1,5 @@
 {{- if .Values.serviceMonitor.enabled }}
-apiVersion: monitoring.coreos.com/v1
-kind: ServiceMonitor
-metadata:
-  name: {{ include "script-exporter.fullname" . }}
-  labels:
-    {{- include "script-exporter.labels" . | nindent 4 }}
-    {{- include "script-exporter.serviceMonitorLabels" . | nindent 4 }}
-    namespace: {{ default .Release.Namespace .Values.serviceMonitor.namespace }}
-spec:
-  endpoints:
-    - port: http
-      {{- with .Values.serviceMonitor.interval }}
-      interval: {{ . }}
-      {{- end }}
-      {{- with .Values.serviceMonitor.scrapeTimeout }}
-      scrapeTimeout: {{ . }}
-      {{- end }}
-      path: /metrics
-      honorLabels: {{ .Values.serviceMonitor.honorLabels }}
-      {{- with .Values.serviceMonitor.metricRelabelings }}
-      metricRelabelings:
-      {{ toYaml . | nindent 6 }}
-      {{- end }}
-      {{- with .Values.serviceMonitor.relabelings }}
-      relabelings:
-      {{ toYaml . | nindent 6 }}
-      {{- end }}
-  namespaceSelector:
-    matchNames:
-      - {{ .Release.Namespace }}
-  selector:
-    matchLabels:
-      {{- include "script-exporter.selectorLabels" . | nindent 6 }}
+{{- if .Values.serviceMonitor.autoCreate.enabled }}
 {{- range (fromYaml .Values.config).scripts }}
 ---
 apiVersion: monitoring.coreos.com/v1
@@ -46,13 +14,29 @@ spec:
   endpoints:
     - path: /probe
       port: http
+      {{- with $.Values.serviceMonitor.interval }}
+      interval: {{ . }}
+      {{- end }}
+      {{- with $.Values.serviceMonitor.scrapeTimeout }}
+      scrapeTimeout: {{ . }}
+      {{- end }}
       params:
         script:
           - {{ .name }}
+      metricRelabelings:
+        - action: replace
+          replacement: {{ .name }}
+          targetLabel: script
+      {{- with $.Values.serviceMonitor.metricRelabelings }}
+      {{- toYaml . | nindent 8 }}
+      {{- end }}
       relabelings:
         - action: replace
           replacement: {{ .name }}
           targetLabel: script
+      {{- with $.Values.serviceMonitor.relabelings }}
+      {{- toYaml . | nindent 8 }}
+      {{- end }}
   namespaceSelector:
     matchNames:
       - {{ $.Release.Namespace }}
@@ -60,4 +44,53 @@ spec:
     matchLabels:
       {{- include "script-exporter.selectorLabels" $ | nindent 6 }}
 {{- end }}
-{{- end -}}
+{{- else }}
+{{- range .Values.serviceMonitor.targets }}
+---
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  labels:
+    {{- include "script-exporter.labels" $ | nindent 4 }}
+    {{- include "script-exporter.serviceMonitorLabels" $ | nindent 4 }}
+    {{- with .labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  name: {{ include "script-exporter.fullname" $ }}-{{ kebabcase .name }}
+  namespace: {{ default $.Release.Namespace $.Values.serviceMonitor.namespace }}
+spec:
+  endpoints:
+    - path: /probe
+      port: http
+      {{- with .interval | default $.Values.serviceMonitor.interval }}
+      interval: {{ . }}
+      {{- end }}
+      {{- with .scrapeTimeout | default $.Values.serviceMonitor.scrapeTimeout }}
+      scrapeTimeout: {{ . }}
+      {{- end }}
+      params:
+        script:
+          - {{ .script }}
+      metricRelabelings:
+        - action: replace
+          replacement: {{ .script }}
+          targetLabel: script
+      {{- with .additionalMetricsRelabels | default $.Values.serviceMonitor.metricRelabelings }}
+      {{- toYaml . | nindent 8 }}
+      {{- end }}
+      relabelings:
+        - action: replace
+          replacement: {{ .script }}
+          targetLabel: script
+      {{- with .additionalRelabeling | default $.Values.serviceMonitor.relabelings }}
+      {{- toYaml . | nindent 8 }}
+      {{- end }}
+  namespaceSelector:
+    matchNames:
+      - {{ $.Release.Namespace }}
+  selector:
+    matchLabels:
+      {{- include "script-exporter.selectorLabels" $ | nindent 6 }}
+{{- end }}
+{{- end }}
+{{- end }}

--- a/charts/script-exporter/values.yaml
+++ b/charts/script-exporter/values.yaml
@@ -127,13 +127,17 @@ serviceAccount:
 serviceMonitor:
   enabled: false
 
+  ## Namespace for the ServiceMonitor. Fallback to the the release namespace.
+  ##
+  namespace: ""
+
   ## Interval at which metrics should be scraped. Fallback to the Prometheus default unless specified.
   ##
-  # interval: 10s
+  interval: ""
 
   ## Timeout after which the scrape is ended. Fallback to the Prometheus default unless specified.
   ##
-  # scrapeTimeout: 30s
+  scrapeTimeout: ""
 
   ## Additional labels that are used by the Prometheus installed in your cluster to select Service Monitors to work with
   ## See: https://github.com/coreos/prometheus-operator/blob/master/Documentation/api.md#prometheusspec

--- a/charts/script-exporter/values.yaml
+++ b/charts/script-exporter/values.yaml
@@ -125,6 +125,21 @@ serviceAccount:
 ## See: https://github.com/coreos/prometheus-operator
 ##
 serviceMonitor:
+  ## If true, a ServiceMonitor CRD is created for a prometheus operator
+  ## https://github.com/coreos/prometheus-operator for script-exporter itself
+  ##
+  selfMonitor:
+    enabled: true
+    additionalMetricsRelabels: {}
+    additionalRelabeling: []
+    labels: {}
+    path: /metrics
+    interval: 30s
+    scrapeTimeout: 30s
+
+  ## If true, a ServiceMonitor CRD is created for a prometheus operator
+  ## https://github.com/coreos/prometheus-operator for each target
+  ##
   enabled: false
 
   ## Namespace for the ServiceMonitor. Fallback to the the release namespace.
@@ -165,6 +180,21 @@ serviceMonitor:
     #   targetLabel: nodename
     #   replacement: $1
     #   action: replace
+
+  ## Automatically create a serviceMonitor for each script defined in the 'config' section below
+  ## This option is mutaly exclusive with the following 'targets' list
+  ##
+  autoCreate:
+    enabled: true
+
+  targets: []
+    # - name: example                    # Human readable URL that will appear in Prometheus / AlertManager
+    #   script: ping                     # Name of the script to target.
+    #   labels: {}                       # Map of labels for ServiceMonitor. Overrides value set in `defaults`
+    #   interval: 60s                    # Scraping interval. Overrides value set in `defaults`
+    #   scrapeTimeout: 60s               # Scrape timeout. Overrides value set in `defaults`
+    #   additionalMetricsRelabels: []    # List of metric relabeling actions to run
+    #   additionalRelabeling: []         # List of relabeling actions to run
 
 ## The configuration for the script_exporter as shown in
 ## https://github.com/ricoberger/script_exporter/tree/main#usage-and-configuration


### PR DESCRIPTION
Hi, this PR allows us to track the scripts using a service monitor instead of [manually configuring](https://github.com/ricoberger/script_exporter?tab=readme-ov-file#prometheus-configuration) the prometheus additional scrape configs. 

If you prefer adding a separate option under `.Values.serviceMonitor` to enable those extra resources I can edit this PR.

I also bumped the image tag to `v2.17.0` in the `appVersion`.