### PR TITLE
feat: Python support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ COPY . .
 RUN export CGO_ENABLED=0 && make build
 
 FROM alpine:3.19.1
-RUN apk add --no-cache --update bash curl jq ca-certificates tini
+RUN apk add --no-cache --update bash curl jq ca-certificates tini python3
 COPY --from=build /build/bin/script_exporter /bin/script_exporter
 EXPOSE 9469
 ENTRYPOINT ["/sbin/tini", "--", "/bin/script_exporter"]


### PR DESCRIPTION
Some of the scripts I want to run are too complex for bash.  This adds python3 into the container so you can run scripts with `#!/usr/bin/python3` shebang.