### PR TITLE
Re-add the `-version` Flag

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ VERSION     ?= $(shell git describe --tags)
 REVISION    ?= $(shell git rev-parse HEAD)
 BRANCH      ?= $(shell git rev-parse --abbrev-ref HEAD)
 BUILDUSER   ?= $(shell id -un)
-BUILDTIME   ?= $(shell date '+%Y%m%d-%H:%M:%S')
+BUILDTIME   ?= $(shell date '+%Y-%m-%d@%H:%M:%S')
 
 .PHONY: build build-darwin-amd64 build-linux-amd64 build-linux-armv7 build-linux-arm64 build-windows-amd64 clean release release-major release-minor release-patch
 

--- a/README.md
+++ b/README.md
@@ -48,14 +48,24 @@ The script_exporter is configured via a configuration file and command-line flag
 
 ```txt
 Usage of ./bin/script_exporter:
+  -config.check
+        Do not run the exporter. Only check the configuration file and exit (0 if the Configuration file is valid, 1 otherwise).
   -config.file file
         Configuration file in YAML format. (default "config.yaml")
   -create-token
         Create bearer token for authentication.
+  -log.env
+        Log environment variables used by a script.
+  -log.format string
+        Output format of log messages. One of: [logfmt, json] (default "logfmt")
+  -log.level string
+        Only log messages with the given severity or above. One of: [debug, info, warn, error] (default "info")
+  -noargs
+        Restrict script to accept arguments, for security issues
   -timeout-offset seconds
         Offset to subtract from Prometheus-supplied timeout in seconds. (default 0.5)
   -version
-        Show version information.
+        Print version information.
   -web.listen-address string
         Address to listen on for web interface and telemetry. (default ":9469")
 ```

--- a/pkg/exporter/exporter.go
+++ b/pkg/exporter/exporter.go
@@ -104,6 +104,7 @@ func InitExporter() (e *Exporter) {
 	logFormat := flag.String("log.format", "logfmt", "Output format of log messages. One of: [logfmt, json]")
 	logEnv := flag.Bool("log.env", false, "Log environment variables used by a script.")
 	configCheck := flag.Bool("config.check", false, "Do not run the exporter. Only check the configuration file and exit (0 if the Configuration file is valid, 1 otherwise).")
+	printVersion := flag.Bool("version", false, "Print version information.")
 
 	flag.Parse()
 
@@ -122,6 +123,17 @@ func InitExporter() (e *Exporter) {
 		var logger log.Logger
 		level.Error(logger).Log("msg", "Failed to init custom logger", "err", err)
 		os.Exit(1)
+	}
+
+	if *printVersion {
+		v, err := version.Print("script_exporter")
+		if err != nil {
+			level.Error(logger).Log("Failed to print version information", "err", err)
+			os.Exit(1)
+		}
+
+		fmt.Fprintln(os.Stdout, v)
+		os.Exit(0)
 	}
 
 	// Avoid problems by erroring out if we have any remaining


### PR DESCRIPTION
The flag was still mentioned in the readme, but was not availble anymore. This commit re-adds the flag and adjusts the usage instructions in the readme.

Closes #131