### PR TITLE
[chart] Fix condition for enabling selfServiceMonitor

### DIFF
--- a/charts/script-exporter/Chart.yaml
+++ b/charts/script-exporter/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: script-exporter
 description: Prometheus exporter to execute scripts and collect metrics from the output or the exit status.
 type: application
-version: 0.8.3
+version: 0.8.4
 appVersion: v2.19.0

--- a/charts/script-exporter/templates/selfservicemonitor.yaml
+++ b/charts/script-exporter/templates/selfservicemonitor.yaml
@@ -1,4 +1,3 @@
-{{- if .Values.serviceMonitor.enabled }}
 {{- if .Values.serviceMonitor.selfMonitor.enabled }}
 ---
 apiVersion: monitoring.coreos.com/v1
@@ -34,5 +33,4 @@ spec:
   selector:
     matchLabels:
       {{- include "script-exporter.selectorLabels" . | nindent 6 }}
-{{- end }}
 {{- end }}

--- a/charts/script-exporter/templates/selfservicemonitor.yaml
+++ b/charts/script-exporter/templates/selfservicemonitor.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.serviceMonitor.enabled }}
 {{- if .Values.serviceMonitor.selfMonitor.enabled }}
 ---
 apiVersion: monitoring.coreos.com/v1
@@ -33,4 +34,5 @@ spec:
   selector:
     matchLabels:
       {{- include "script-exporter.selectorLabels" . | nindent 6 }}
+{{- end }}
 {{- end }}

--- a/charts/script-exporter/values.yaml
+++ b/charts/script-exporter/values.yaml
@@ -129,7 +129,7 @@ serviceMonitor:
   ## https://github.com/coreos/prometheus-operator for script-exporter itself
   ##
   selfMonitor:
-    enabled: true
+    enabled: false
     additionalMetricsRelabels: {}
     additionalRelabeling: []
     labels: {}


### PR DESCRIPTION
I believe selfServiceMonitor shouldn't be enabled until serviceMonitor is also enabled. Otherwise it's better to move its configuration to separate/independent section and disable by default same way as serviceMonitor.

Otherwise I got the error:

```console
no matches for kind "ServiceMonitor" in version "monitoring.coreos.com/v1" ensure CRDs are installed first
```
This is because I don't use it and thus didn't install this CRD at all but chart worked for me but failed when I tried to upgrade it from 0.6.2 to 0.8.3.