### PR TITLE
feat: use query params as env

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,9 @@ scripts:
     command: <string>
     args:
       - <string>
+    # by default the env cannot be overwritten by query parameters.
+    # If you want to change this, set this option to true
+    allowEnvOverwrite: <bool>
     # optional
     env:
       <key>: <value>

--- a/examples/config.yaml
+++ b/examples/config.yaml
@@ -21,7 +21,9 @@ discovery:
 scripts:
   - name: ping
     command: ./examples/ping.sh
-    cacheDuration: 1m
+    allowEnvOverwrite: true
+    env:
+      target_ips: "127.0.0.1"
   - name: helloworld
     command: ./examples/helloworld.sh
     args:

--- a/examples/ping.sh
+++ b/examples/ping.sh
@@ -1,4 +1,7 @@
 #!/bin/bash
+# exit script on error
+set -e
 
-ping -c 3 $1 > /dev/null 2>&1
-exit $?
+while read -r ip; do
+  ping -c 3 $ip &> /dev/null
+done < <(echo "$target_ips" | tr ',' '\n')

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -65,6 +65,7 @@ type ScriptConfig struct {
 	Command            string            `yaml:"command"`
 	Args               []string          `yaml:"args"`
 	Env                map[string]string `yaml:"env"`
+	AllowEnvOverwrite  bool              `yaml:"allowEnvOverwrite"`
 	IgnoreOutputOnFail bool              `yaml:"ignoreOutputOnFail"`
 	Timeout            timeout           `yaml:"timeout"`
 	CacheDuration      string            `yaml:"cacheDuration"`
@@ -175,7 +176,17 @@ func (c *Config) GetRunEnv(scriptName string) map[string]string {
 			break
 		}
 	}
-	return nil
+	return map[string]string{}
+}
+
+// GetAllowEnvOverwrite returns the allowEnvOverwrite parameter for the provided script.
+func (c *Config) GetAllowEnvOverwrite(scriptName string) bool {
+	for _, script := range c.Scripts {
+		if script.Name == scriptName {
+			return script.AllowEnvOverwrite
+		}
+	}
+	return false
 }
 
 // GetIgnoreOutputOnFail returns the ignoreOutputOnFail parameter for the provided script.

--- a/pkg/exporter/metrics.go
+++ b/pkg/exporter/metrics.go
@@ -67,6 +67,14 @@ func (e *Exporter) metricsHandler(scriptName string, params url.Values, promethe
 	// Get env vars
 	runEnv := e.Config.GetRunEnv(scriptName)
 
+	envOverwriteAllowed := e.Config.GetAllowEnvOverwrite(scriptName)
+
+	for key, paramValues := range params {
+		if _, ok := runEnv[key]; !ok || envOverwriteAllowed {
+			runEnv[key] = strings.Join(paramValues, ",")
+		}
+	}
+
 	// Success status of the executed script
 	successStatus := 1
 


### PR DESCRIPTION
I want to access my query parameters not only by position but by name.
Merging this change will allow for scripts to read the query parameters as environment variables.
I want to deploy multiple SMons that query my script with different parameters each and the order of these parameters is something I don't want to debug.

I thought about the risk of overwriting important env variables, but this is up to the user to overwrite and shoot themselves in the foot, IMO.