### PR TITLE
feat: add parameter to allow return expired cache in case of errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,7 @@ scripts:
       max_timeout: <float>
       enforced: <boolean>
     cacheDuration: <duration>
+    useExpiredCacheOnError: <boolean>
     discovery:
       params:
         <string>: <string>
@@ -160,7 +161,9 @@ Prometheus will normally provide an indication of its scrape timeout to the scri
 
 For testing purposes, the timeout can be specified directly as a URL parameter (`timeout`). If present, the URL parameter takes priority over the Prometheus HTTP header.
 
-The `cacheDuration` config can be used to cache the results from an execution of the script for the provided time. The provided duration must be parsable by the [`time.ParseDuration`](https://pkg.go.dev/time#ParseDuration) function. If no cache duration is provided or the provided cache duration can not be parsed, the output of an script will not be cached.
+The `cacheDuration` config can be used to cache the results from an execution of the script for the provided time. The provided duration must be parsable by the [`time.ParseDuration`](https://pkg.go.dev/time#ParseDuration) function. If no cache duration is provided or the provided cache duration can not be parsed, the output of an script will not be cached. It produces the metric `script_use_cache` to track in time when results returned are coming from cache.
+
+The `useExpiredCacheOnError` config allow to return expired cache in case of errors. It produces the metric `script_use_expired_cache` for track in time if you are using expired cache, it mean there is something wrong with the script execution.
 
 You can fine tune the script discovery options via optional script `discovery`. All these options will go through prometheus configuration where you can change them via relabel mechanism.
 There are `params` to define dynamic script parameters (with reserved keys: `params`, `prefix`, `script` and `timeout`) where only value will be used during script invoking (similar to `args`), `prefix` to define prefix for all script metrics, `scrape_interval` to define how often the script scrape should run and `scrape_timeout` to define the scrape timeout for prometheus (similar to `timeout`).

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -60,16 +60,17 @@ type Config struct {
 
 // ScriptConfig is the configuration for a single script.
 type ScriptConfig struct {
-	Name               string            `yaml:"name"`
-	Script             string            `yaml:"script"`
-	Command            string            `yaml:"command"`
-	Args               []string          `yaml:"args"`
-	Env                map[string]string `yaml:"env"`
-	AllowEnvOverwrite  bool              `yaml:"allowEnvOverwrite"`
-	IgnoreOutputOnFail bool              `yaml:"ignoreOutputOnFail"`
-	Timeout            timeout           `yaml:"timeout"`
-	CacheDuration      string            `yaml:"cacheDuration"`
-	Discovery          scriptDiscovery   `yaml:"discovery"`
+	Name                   string            `yaml:"name"`
+	Script                 string            `yaml:"script"`
+	Command                string            `yaml:"command"`
+	Args                   []string          `yaml:"args"`
+	Env                    map[string]string `yaml:"env"`
+	AllowEnvOverwrite      bool              `yaml:"allowEnvOverwrite"`
+	IgnoreOutputOnFail     bool              `yaml:"ignoreOutputOnFail"`
+	Timeout                timeout           `yaml:"timeout"`
+	UseExpiredCacheOnError bool              `yaml:"useExpiredCacheOnError"`
+	CacheDuration          string            `yaml:"cacheDuration"`
+	Discovery              scriptDiscovery   `yaml:"discovery"`
 }
 
 // LoadConfig reads the configuration file and umarshal the data into the config struct
@@ -249,6 +250,16 @@ func (c *Config) GetCacheDuration(scriptName string) *time.Duration {
 		}
 	}
 	return nil
+}
+
+// GetUseExpiredCacheOnError returns the UseExpiredCacheOnError parameter for the provided script.
+func (c *Config) GetUseExpiredCacheOnError(scriptName string) bool {
+	for _, script := range c.Scripts {
+		if script.Name == scriptName {
+			return script.UseExpiredCacheOnError
+		}
+	}
+	return false
 }
 
 // GetDiscoveryScrapeInterval returns the scrape_interval if it is valid duration, otherwise empty string.

--- a/pkg/exporter/cache.go
+++ b/pkg/exporter/cache.go
@@ -15,9 +15,9 @@ type cacheEntry struct {
 	successStatus   int
 }
 
-func getCacheResult(scriptName string, paramValues []string, cacheDuration time.Duration) (*string, *int, *int) {
+func getCacheResult(scriptName string, paramValues []string, cacheDuration time.Duration, expCacheOnTimeout bool) (*string, *int, *int) {
 	if entry, ok := cache[fmt.Sprintf("%s--%s", scriptName, strings.Join(paramValues, "-"))]; ok {
-		if entry.cacheTime.Add(cacheDuration).After(time.Now()) {
+		if entry.cacheTime.Add(cacheDuration).After(time.Now()) || expCacheOnTimeout {
 			return &entry.formattedOutput, &entry.successStatus, &entry.exitCode
 		}
 	}

--- a/pkg/exporter/exporter.go
+++ b/pkg/exporter/exporter.go
@@ -32,6 +32,10 @@ const (
 	scriptDurationSecondsType = "# TYPE script_duration_seconds gauge"
 	scriptExitCodeHelp        = "# HELP script_exit_code The exit code of the script."
 	scriptExitCodeType        = "# TYPE script_exit_code gauge"
+	scriptCacheHelp           = "# HELP script_use_cache Script use cache (0 = no, 1 = yes)."
+	scriptCacheType           = "# TYPE script_use_cache gauge"
+	scriptExpCacheHelp        = "# HELP script_use_expired_cache Script re-use expired cache (0 = no, 1 = yes)."
+	scriptExpCacheType        = "# TYPE script_use_expired_cache gauge"
 )
 
 type Exporter struct {


### PR DESCRIPTION
Hi @ricoberger,

I would like to add this feature with the parameter `useExpiredCacheOnError`, in some case it help when we have a script execution doing some flip/flap caused by a timeout.

With theses parameters:
```
useExpiredCacheOnError: true
cacheDuration: 5m
```

It produces the following metrics:
```
# TYPE script_use_cache gauge
script_use_cache{script="get_objecstorage_tenant_usage"} 1
# HELP script_use_expired_cache Script re-use expired cache (0 = no, 1 = yes).
# TYPE script_use_expired_cache gauge
script_use_expired_cache{script="get_objecstorage_tenant_usage"} 1
```

I added the metric `script_use_cache` as it could be interesting to know if metrics are coming from cache or not.

Let me know what do you think about that.