### PR TITLE
Add GitHub Container Registry

### DIFF
--- a/.github/workflows/continuous-delivery-docker.yaml
+++ b/.github/workflows/continuous-delivery-docker.yaml
@@ -38,6 +38,13 @@ jobs:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
 
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Build and Push Docker Image
         id: docker_build
         uses: docker/build-push-action@v6
@@ -46,4 +53,8 @@ jobs:
           context: .
           file: ./Dockerfile
           platforms: linux/386,linux/amd64,linux/arm/v7,linux/arm64/v8
-          tags: ricoberger/script_exporter:${{ env.TAG }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          tags: |
+            ghcr.io/${{ github.repository }}:${{ env.TAG }}
+            ricoberger/script_exporter:${{ env.TAG }}

--- a/README.md
+++ b/README.md
@@ -21,8 +21,8 @@ An example configuration can be found in the [examples](./examples) folder. To u
 To run the examples via Docker the following commands can be used:
 
 ```sh
-docker build -f ./Dockerfile -t ricoberger/script_exporter:dev .
-docker run --rm -it --name script_exporter -p 9469:9469 -v $(pwd)/examples:/examples ricoberger/script_exporter:dev -config.file /examples/config.yaml
+docker build -f ./Dockerfile -t ghcr.io/ricoberger/script_exporter:dev .
+docker run --rm -it --name script_exporter -p 9469:9469 -v $(pwd)/examples:/examples ghcr.io/ricoberger/script_exporter:dev -config.file /examples/config.yaml
 ```
 
 Then visit [http://localhost:9469](http://localhost:9469) in the browser of your choice. There you have access to the following examples:

--- a/charts/script-exporter/Chart.yaml
+++ b/charts/script-exporter/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: script-exporter
 description: Prometheus exporter to execute scripts and collect metrics from the output or the exit status.
 type: application
-version: 0.8.7
-appVersion: v2.21.0
+version: 0.9.0
+appVersion: v2.22.0

--- a/charts/script-exporter/values.yaml
+++ b/charts/script-exporter/values.yaml
@@ -19,7 +19,7 @@ imagePullSecrets: []
 ## Set the image which should be used for script_exporter.
 ##
 image:
-  repository: ricoberger/script_exporter
+  repository: ghcr.io/ricoberger/script_exporter
   pullPolicy: IfNotPresent
   # Overrides the image tag whose default is the chart appVersion.
   tag: ""


### PR DESCRIPTION
Add the Docker image to the GitHub Container Registry as alternative to DockerHub and make GHCR the default in the Helm chart.

This commit also adds the `cache-from` and `cache-to` parameters to the GitHub Action to build the Docker image.