### PR TITLE
Add configurable path for script-exporter config file

### DIFF
--- a/charts/script-exporter/Chart.yaml
+++ b/charts/script-exporter/Chart.yaml
@@ -1,6 +1,7 @@
+---
 apiVersion: v2
 name: script-exporter
 description: Prometheus exporter to execute scripts and collect metrics from the output or the exit status.
 type: application
-version: 0.9.0
+version: 0.10.0
 appVersion: v2.22.0

--- a/charts/script-exporter/templates/deployment.yaml
+++ b/charts/script-exporter/templates/deployment.yaml
@@ -38,7 +38,7 @@ spec:
             {{- toYaml . | nindent 12 }}
           {{- end }}
           args:
-            - -config.file=/etc/script-exporter/config.yaml
+            - -config.file={{ .Values.configFile | default "/etc/script-exporter/config.yaml" }}
           ports:
             - name: http
               containerPort: 9469

--- a/charts/script-exporter/values.yaml
+++ b/charts/script-exporter/values.yaml
@@ -196,6 +196,9 @@ serviceMonitor:
     #   additionalMetricsRelabels: []    # List of metric relabeling actions to run
     #   additionalRelabeling: []         # List of relabeling actions to run
 
+## The configuration file path for the script_exporter. It defaults to "/etc/script-exporter/config.yaml".
+configFile: ""
+
 ## The configuration for the script_exporter as shown in
 ## https://github.com/ricoberger/script_exporter/tree/main#usage-and-configuration
 ##


### PR DESCRIPTION
**Description**
This pull request adds the configFile parameter to the values.yaml file in the Helm chart. This parameter allows users to override the script_exporter configuration file argument.

**Motivation**
Adding the configFile parameter is useful for scenarios where the configuration file is mounted from an external source. This provides greater flexibility in managing the script_exporter configuration.

**Changes**
Added configFile parameter to values.yaml to override the script_exporter configuration file argument.