### PR TITLE
Fix Race Condition when Cache is Used

### DIFF
--- a/examples/config.yaml
+++ b/examples/config.yaml
@@ -1,3 +1,4 @@
+---
 tls:
   enabled: false
   crt: server.crt
@@ -13,10 +14,10 @@ bearerAuth:
   signingKey: my_secret_key
 
 discovery:
-  # host: localhost
-  # port: 1231
-  # scheme: https
-  # path: /prefix-path
+# host: localhost
+# port: 1231
+# scheme: https
+# path: /prefix-path
 
 scripts:
   - name: ping
@@ -24,6 +25,7 @@ scripts:
     allowEnvOverwrite: true
     env:
       target_ips: "127.0.0.1"
+    cacheDuration: 1m
   - name: helloworld
     command: ./examples/helloworld.sh
     args:

--- a/pkg/exporter/cache.go
+++ b/pkg/exporter/cache.go
@@ -3,10 +3,12 @@ package exporter
 import (
 	"fmt"
 	"strings"
+	"sync"
 	"time"
 )
 
 var cache map[string]cacheEntry
+var cacheLock = sync.RWMutex{}
 
 type cacheEntry struct {
 	cacheTime       time.Time
@@ -16,6 +18,9 @@ type cacheEntry struct {
 }
 
 func getCacheResult(scriptName string, paramValues []string, cacheDuration time.Duration, expCacheOnTimeout bool) (*string, *int, *int) {
+	cacheLock.RLock()
+	defer cacheLock.RUnlock()
+
 	if entry, ok := cache[fmt.Sprintf("%s--%s", scriptName, strings.Join(paramValues, "-"))]; ok {
 		if entry.cacheTime.Add(cacheDuration).After(time.Now()) || expCacheOnTimeout {
 			return &entry.formattedOutput, &entry.successStatus, &entry.exitCode
@@ -26,6 +31,9 @@ func getCacheResult(scriptName string, paramValues []string, cacheDuration time.
 }
 
 func setCacheResult(scriptName string, paramValues []string, formattedOutput string, successStatus, exitCode int) {
+	cacheLock.Lock()
+	defer cacheLock.Unlock()
+
 	if cache == nil {
 		cache = make(map[string]cacheEntry)
 	}


### PR DESCRIPTION
When to requests were accessing the cache during the same time, there
was a race condition because of the concurrent access to the map which
holds the cached entries.

This is now fixed by adding a lock for the cache, so that multiple
requests can not access the cache in parallel.

Fixes #157
