### PR TITLE
Add sudo config parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,7 @@ discovery:
 scripts:
   - name: <string>
     command: <string>
+    sudo: <boolean>
     args:
       - <string>
     # by default the env cannot be overwritten by query parameters.
@@ -123,7 +124,9 @@ scripts_configs:
   - <string>
 ```
 
-The `name` of the script must be a valid Prometheus label value. The `command` string is the script which is executed with all arguments specified in `args`. To add dynamic arguments you can pass the `params` query parameter with a list of query parameters which values should be added as argument. The program will be executed directly, without a shell being invoked, and it is recommended that it be specified by path instead of relying on ``$PATH``.
+The `name` of the script must be a valid Prometheus label value. The `command` string is the script which is executed with all arguments specified in `args`. To add dynamic arguments you can pass the `params` query parameter with a list of query parameters which values should be added as argument. The program will be executed directly, without a shell being invoked, and it is recommended that it be specified by path instead of relying on ``$PATH``. 
+
+If `sudo` is defined and set to `true`, the command will be executed with privileged (root) permissions by executing the `command` with a pre-fixed `sudo`. Note that you still need to create the relevant sudoers entries, script_exporter will not do this for you.
 
 The optional `env` key allows to run the script with custom environment variables.
 

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -71,6 +71,7 @@ type ScriptConfig struct {
 	UseExpiredCacheOnError bool              `yaml:"useExpiredCacheOnError"`
 	CacheDuration          string            `yaml:"cacheDuration"`
 	Discovery              scriptDiscovery   `yaml:"discovery"`
+	Sudo                   bool              `yaml:"sudo"`
 }
 
 // LoadConfig reads the configuration file and umarshal the data into the config struct
@@ -159,6 +160,9 @@ func (c *Config) GetRunArgs(scriptName string) ([]string, error) {
 				return strings.Split(script.Script, " "), nil
 			}
 			var runArgs []string
+			if script.Sudo {
+				runArgs = append(runArgs, "sudo")
+			}
 			runArgs = append(runArgs, script.Command)
 			runArgs = append(runArgs, script.Args...)
 			return runArgs, nil


### PR DESCRIPTION
This PR was made to solve the `sudo` problem, I ran into in #171 . 
The additional configuration parameter `sudo` is added in this PR and allows to define scripts which should be executed with privileged (root) permissions.

I've successfully tested this with a particular script which only runs correctly when executed as root. 

```
  - name: check_example
    command: /opt/check_example.py
    args:
      - "-o"
      - "prometheus"
    timeout:
      max_timeout: 60
```


script_exporter runs as unprivileged user. When the particular script is run (`curl localhost:9469/probe?script=check_example`), the script returns an error:

```
ts=2024-12-19T14:07:31.771Z caller=scripts.go:93 level=error msg="Script 'check_example' execution failed" cmd="/opt/check_example.py -o prometheus" stdout="ERROR: Unable to decode JSON, Error: Expecting value: line 1 column 1 (char 0).\n" stderr= env= err="exit status 3"
```

Now adjusting the script config and adding the `sudo` option:
```
  - name: check_example
    command: /opt/check_example.py
    sudo: true
    args:
      - "-o"
      - "prometheus"
    timeout:
      max_timeout: 60
```

Starting the patched script_exporter and executing the script (`curl localhost:9469/probe?script=check_example`), the command is successfully executed with sudo:

```
curl localhost:9469/probe?script=check_example
# HELP script_success Script exit status (0 = error, 1 = success).
# TYPE script_success gauge
script_success{script="check_example"} 1
# HELP script_duration_seconds Script execution time, in seconds.
# TYPE script_duration_seconds gauge
script_duration_seconds{script="check_example"} 7.313547
# HELP script_exit_code The exit code of the script.
# TYPE script_exit_code gauge
script_exit_code{script="check_example"} 0
# HELP script_use_cache Script use cache (0 = no, 1 = yes).
# TYPE script_use_cache gauge
script_use_cache{script="check_example"} 0
# HELP script_use_expired_cache Script re-use expired cache (0 = no, 1 = yes).
# TYPE script_use_expired_cache gauge
script_use_expired_cache{script="check_example"} 0
HELP example_perf_status shows performance value of example script
TYPE example_perf_status gauge
example_perf_status 0
```

The relevant system security logs confirm this, too:

```
Dec 19 15:09:03 linux sudo[3023247]:    user : TTY=pts/0 ; PWD=/home/user ; USER=root ; COMMAND=/opt/check_example.py -o prometheus
```

This additional config option is very helpful, when script_exporter is NOT run as root user (which should be the default IMO, but that's out of scope of this PR).

Let me know if this PR needs further adjustments. 
