### PR TITLE
Helm Chart: Adjust ServiceMonitors

### DIFF
--- a/charts/script-exporter/Chart.yaml
+++ b/charts/script-exporter/Chart.yaml
@@ -1,7 +1,9 @@
 ---
 apiVersion: v2
 name: script-exporter
-description: Prometheus exporter to execute scripts and collect metrics from the output or the exit status.
+description:
+  Prometheus exporter to execute scripts and collect metrics from the output or
+  the exit status.
 type: application
-version: 1.0.0
+version: 2.0.0
 appVersion: v2.24.0

--- a/charts/script-exporter/templates/_helpers.tpl
+++ b/charts/script-exporter/templates/_helpers.tpl
@@ -94,3 +94,12 @@ Additional labels for the Service Monitor
 {{- toYaml .Values.serviceMonitor.labels }}
 {{- end }}
 {{- end }}
+
+{{/*
+Additional labels for the self Service Monitor
+*/}}
+{{- define "script-exporter.selfServiceMonitorLabels" -}}
+{{- if .Values.selfServiceMonitor.labels }}
+{{- toYaml .Values.selfServiceMonitor.labels }}
+{{- end }}
+{{- end }}

--- a/charts/script-exporter/templates/selfservicemonitor.yaml
+++ b/charts/script-exporter/templates/selfservicemonitor.yaml
@@ -1,29 +1,29 @@
-{{- if .Values.serviceMonitor.selfMonitor.enabled }}
+{{- if .Values.selfServiceMonitor.enabled }}
 ---
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
   labels:
     {{- include "script-exporter.labels" . | nindent 4 }}
-    {{- include "script-exporter.serviceMonitorLabels" . | nindent 4 }}
+    {{- include "script-exporter.selfServiceMonitorLabels" . | nindent 4 }}
   name: {{ include "script-exporter.fullname" . }}
-  namespace: {{ default .Release.Namespace .Values.serviceMonitor.namespace }}
+  namespace: {{ default .Release.Namespace .Values.selfServiceMonitor.namespace }}
 spec:
   endpoints:
-    - port: http
-      {{- with .Values.serviceMonitor.interval }}
+    - path: /metrics
+      port: http
+      {{- with .Values.selfServiceMonitor.interval }}
       interval: {{ . }}
       {{- end }}
-      {{- with .Values.serviceMonitor.scrapeTimeout }}
+      {{- with .Values.selfServiceMonitor.scrapeTimeout }}
       scrapeTimeout: {{ . }}
       {{- end }}
-      path: /metrics
-      honorLabels: {{ .Values.serviceMonitor.honorLabels }}
-      {{- with .Values.serviceMonitor.metricRelabelings }}
+      honorLabels: {{ .Values.selfServiceMonitor.honorLabels }}
+      {{- with .Values.selfServiceMonitor.metricRelabelings }}
       metricRelabelings:
       {{ toYaml . | nindent 6 }}
       {{- end }}
-      {{- with .Values.serviceMonitor.relabelings }}
+      {{- with .Values.selfServiceMonitor.relabelings }}
       relabelings:
       {{ toYaml . | nindent 6 }}
       {{- end }}

--- a/charts/script-exporter/templates/servicemonitor.yaml
+++ b/charts/script-exporter/templates/servicemonitor.yaml
@@ -23,6 +23,9 @@ spec:
       params:
         script:
           - {{ .name }}
+      {{- with $.Values.serviceMonitor.honorLabels }}
+      honorLabels: {{ . }}
+      {{- end }}
       metricRelabelings:
         - action: replace
           replacement: {{ .name }}
@@ -71,6 +74,9 @@ spec:
       params:
         script:
           - {{ .script }}
+      {{- with .honorLabels | default $.Values.serviceMonitor.honorLabels }}
+      honorLabels: {{ . }}
+      {{- end }}
       metricRelabelings:
         - action: replace
           replacement: {{ .script }}

--- a/charts/script-exporter/values.yaml
+++ b/charts/script-exporter/values.yaml
@@ -28,14 +28,16 @@ image:
 ## the corresponding "securityContext" field.
 ## See: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod
 ##
-podSecurityContext: {}
+podSecurityContext:
+  {}
   # fsGroup: 2000
 
 ## Specify security settings for the script_exporter Container. They override settings made at the Pod level via the
 ## "podSecurityContext" when there is overlap.
 ## See: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-container
 ##
-securityContext: {}
+securityContext:
+  {}
   # capabilities:
   #   drop:
   #   - ALL
@@ -48,7 +50,8 @@ securityContext: {}
 ## specify resources, uncomment the following lines, adjust them as necessary, and remove the curly braces after
 ## 'resources:'.
 ##
-resources: {}
+resources:
+  {}
   # limits:
   #   cpu: 100m
   #   memory: 128Mi
@@ -74,7 +77,8 @@ affinity: {}
 ## Topology spread constraints rely on node labels to identify the topology domain(s) that each Node is in.
 ## See: https://kubernetes.io/docs/concepts/workloads/pods/pod-topology-spread-constraints/
 ##
-topologySpreadConstraints: []
+topologySpreadConstraints:
+  []
   # - maxSkew: 1
   #   topologyKey: topology.kubernetes.io/zone
   #   whenUnsatisfiable: DoNotSchedule
@@ -85,7 +89,8 @@ topologySpreadConstraints: []
 ## Specify additional volumes for the script_exporter deployment.
 ## See: https://kubernetes.io/docs/concepts/storage/volumes/
 ##
-volumes: []
+volumes:
+  []
   # - name: scripts
   #   configMap:
   #     name: scripts
@@ -93,14 +98,16 @@ volumes: []
 ## Specify additional volumeMounts for the script_exporter container.
 ## See: https://kubernetes.io/docs/concepts/storage/volumes/
 ##
-volumeMounts: []
+volumeMounts:
+  []
   # - name: scripts
   #   mountPath: /scripts
   #   readOnly: true
 
 ## Specify additional environment variables for the script_exporter container.
 ##
-env: []
+env:
+  []
   # - name: MY_ENV_VAR
   #   value: MY_ENV_VALUE
 
@@ -134,17 +141,71 @@ serviceAccount:
 ##
 serviceMonitor:
   ## If true, a ServiceMonitor CRD is created for a prometheus operator
-  ## https://github.com/coreos/prometheus-operator for script-exporter itself
+  ## https://github.com/coreos/prometheus-operator for each target
   ##
-  selfMonitor:
-    enabled: false
-    additionalMetricsRelabels: {}
-    additionalRelabeling: []
-    labels: {}
-    path: /metrics
-    interval: 30s
-    scrapeTimeout: 30s
+  enabled: false
 
+  ## Namespace for the ServiceMonitor. Fallback to the the release namespace.
+  ##
+  namespace: ""
+
+  ## Interval at which metrics should be scraped. Fallback to the Prometheus default unless specified.
+  ##
+  interval: ""
+
+  ## Timeout after which the scrape is ended. Fallback to the Prometheus default unless specified.
+  ##
+  scrapeTimeout: ""
+
+  ## Additional labels that are used by the Prometheus installed in your cluster to select Service Monitors to work with
+  ## See: https://github.com/coreos/prometheus-operator/blob/master/Documentation/api.md#prometheusspec
+  ##
+  labels: {}
+
+  ## HonorLabels chooses the metric's labels on collisions with target labels.
+  ##
+  honorLabels: true
+
+  ## MetricRelabelConfigs to apply to samples before ingestion.
+  ##
+  metricRelabelings:
+    []
+    # - action: keep
+    #   regex: 'kube_(daemonset|deployment|pod|namespace|node|statefulset).+'
+    #   sourceLabels: [__name__]
+
+  ## RelabelConfigs to apply to samples before scraping. Prometheus Operator automatically adds relabelings for a few
+  ## standard Kubernetes fields and replaces original scrape job name with __tmp_prometheus_job_name.
+  ##
+  relabelings:
+    []
+    # - sourceLabels: [__meta_kubernetes_pod_node_name]
+    #   separator: ;
+    #   regex: ^(.*)$
+    #   targetLabel: nodename
+    #   replacement: $1
+    #   action: replace
+
+  ## Automatically create a serviceMonitor for each script defined in the 'config' section below
+  ## This option is mutaly exclusive with the following 'targets' list
+  ##
+  autoCreate:
+    enabled: true
+
+  targets:
+    []
+    # - name: example                    # Human readable URL that will appear in Prometheus / AlertManager
+    #   script: ping                     # Name of the script to target.
+    #   labels: {}                       # Map of labels for ServiceMonitor. Overrides value set in `defaults`
+    #   interval: 60s                    # Scraping interval. Overrides value set in `defaults`
+    #   scrapeTimeout: 60s               # Scrape timeout. Overrides value set in `defaults`
+    #   additionalMetricsRelabels: []    # List of metric relabeling actions to run
+    #   additionalRelabeling: []         # List of relabeling actions to run
+
+## Create a Service Monitor for the Prometheus Operator.
+## See: https://github.com/coreos/prometheus-operator
+##
+selfServiceMonitor:
   ## If true, a ServiceMonitor CRD is created for a prometheus operator
   ## https://github.com/coreos/prometheus-operator for each target
   ##
@@ -173,7 +234,8 @@ serviceMonitor:
 
   ## MetricRelabelConfigs to apply to samples before ingestion.
   ##
-  metricRelabelings: []
+  metricRelabelings:
+    []
     # - action: keep
     #   regex: 'kube_(daemonset|deployment|pod|namespace|node|statefulset).+'
     #   sourceLabels: [__name__]
@@ -181,28 +243,14 @@ serviceMonitor:
   ## RelabelConfigs to apply to samples before scraping. Prometheus Operator automatically adds relabelings for a few
   ## standard Kubernetes fields and replaces original scrape job name with __tmp_prometheus_job_name.
   ##
-  relabelings: []
+  relabelings:
+    []
     # - sourceLabels: [__meta_kubernetes_pod_node_name]
     #   separator: ;
     #   regex: ^(.*)$
     #   targetLabel: nodename
     #   replacement: $1
     #   action: replace
-
-  ## Automatically create a serviceMonitor for each script defined in the 'config' section below
-  ## This option is mutaly exclusive with the following 'targets' list
-  ##
-  autoCreate:
-    enabled: true
-
-  targets: []
-    # - name: example                    # Human readable URL that will appear in Prometheus / AlertManager
-    #   script: ping                     # Name of the script to target.
-    #   labels: {}                       # Map of labels for ServiceMonitor. Overrides value set in `defaults`
-    #   interval: 60s                    # Scraping interval. Overrides value set in `defaults`
-    #   scrapeTimeout: 60s               # Scrape timeout. Overrides value set in `defaults`
-    #   additionalMetricsRelabels: []    # List of metric relabeling actions to run
-    #   additionalRelabeling: []         # List of relabeling actions to run
 
 ## The configuration file path for the script_exporter. It defaults to "/etc/script-exporter/config.yaml".
 configFile: ""


### PR DESCRIPTION
This commit adjusts the creation of the ServiceMonitors in the Helm
chart and is a breaking change compared to the last Helm chart version.

The `serviceMonitor.selfMonitor` values are moved to
`selfServiceMonitor` and the available values are adjusted to follow a
similar naming as it is used for the `serviceMonitor` values.

The `honorLabels` option is now used within the `selfServiceMonitor` and
`serviceMonitor`.

Closes #183 
