### PR TITLE
Don't Wait for IO Pipes to be Closed

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,9 @@ choice. There you have access to the following examples:
   Pass arguments to the script via the configuration file.
 - [metrics](http://localhost:9469/metrics): Shows internal metrics from the
   script exporter.
+- [sleepscript](http://localhost:9469/probe?script=sleepscript&params=seconds&seconds=20):
+  Execute a script which executes a `sleep` command with the duration provided
+  in the `seconds` parameter. The command will be canceled after 10 seconds.
 
 You can also deploy the script_exporter to Kubernetes via Helm:
 

--- a/examples/config.yaml
+++ b/examples/config.yaml
@@ -40,6 +40,11 @@ scripts:
       - "120"
     timeout:
       enforced: true
+  - name: sleepscript
+    command: ./examples/sleepscript.sh
+    timeout:
+      max_timeout: 10
+      enforced: true
   - name: docker
     command: ./examples/docker.sh
   - name: args

--- a/examples/sleepscript.sh
+++ b/examples/sleepscript.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+
+sleep "$1"
+echo "sleep{seconds=\"$1\"} 1"


### PR DESCRIPTION
When a executed script spawned a child process (e.g. `sleep`) the
timeout was not enforced, because `cmd.Wait()` would wait for the script
to exit and for all IO pipes to be closed. This is now fixed by adding a
`cmd.WaitDelay` of 1ms to kill the process even, if the IO pipes are not
closed.
