### PR TITLE
Fix Build for Binaries

### DIFF
--- a/.github/workflows/continuous-delivery.yaml
+++ b/.github/workflows/continuous-delivery.yaml
@@ -47,9 +47,19 @@ jobs:
 
       - name: Build
         run: |
+          export GOOS=${{ matrix.platform.os }}
+          export GOARCH=${{ matrix.platform.arch }}
+          export CGO_ENABLED=0
+
           make build
-          cp bin/script_exporter script_exporter
-          tar -czf script_exporter-${{ matrix.platform.os }}-${{ matrix.platform.arch }}.tar.gz script_exporter
+
+          if [[ ${{ matrix.platform.os }} == "windows" ]]; then
+            cp bin/script_exporter script_exporter.exe
+            tar -czf script_exporter-${{ matrix.platform.os }}-${{ matrix.platform.arch }}.tar.gz script_exporter.exe
+          else
+            cp bin/script_exporter script_exporter
+            tar -czf script_exporter-${{ matrix.platform.os }}-${{ matrix.platform.arch }}.tar.gz script_exporter
+          fi
 
       - name: Upload Artifact (PR)
         if: ${{ github.event_name == 'pull_request' }}

--- a/cmd/main_unix.go
+++ b/cmd/main_unix.go
@@ -1,3 +1,6 @@
+//go:build darwin || linux
+// +build darwin linux
+
 package main
 
 import (


### PR DESCRIPTION
In the continuous delivery GitHub Action for the binaries the `GOOS`,
`GOARCH` and `CGO_ENABLED` environment variables were not set, so that
the binaries were not build correctly. This is now fixed.

Additionally we had to add a build constraint to the `cmd/main_unix.go`
file, so that the build is working correctly for Windows.

Fixes #199
