### PR TITLE
Add Support to Load Configuration from URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,8 @@ Flags:
   -h, --[no-]help                Show context-sensitive help (also try --help-long and --help-man).
       --config.files="scripts.yaml"
                                  Configuration files. To specify multiple configuration files glob patterns can be used.
+      --config.reload-interval=1h
+                                 Reload interval of the configuration file.
       --[no-]config.check        If true, validate the configuration files and then exit.
       --[no-]log.env             If true, environment variables passed to a script will be logged.
       --[no-]script.no-args      Restrict script to accept arguments.

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -1,6 +1,10 @@
 package config
 
 import (
+	"fmt"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
 	"testing"
 
 	"github.com/prometheus/client_golang/prometheus"
@@ -10,7 +14,7 @@ import (
 func TestNewSafeConfig(t *testing.T) {
 	t.Run("should load configuration", func(t *testing.T) {
 		sc := NewSafeConfig(prometheus.NewRegistry())
-		err := sc.ReloadConfig("./testdata/config-valid.yaml", nil)
+		err := sc.ReloadConfig("./testdata/config-valid.yaml", slog.Default())
 
 		require.NoError(t, err)
 		require.NotNil(t, sc.C)
@@ -29,7 +33,64 @@ func TestNewSafeConfig(t *testing.T) {
 
 	t.Run("should return error for invalid configuration", func(t *testing.T) {
 		sc := NewSafeConfig(prometheus.NewRegistry())
-		err := sc.ReloadConfig("./testdata/config-invalid.yaml", nil)
+		err := sc.ReloadConfig("./testdata/config-invalid.yaml", slog.Default())
+
+		require.Error(t, err)
+	})
+}
+
+func TestNewSafeConfigFromUrl(t *testing.T) {
+	t.Run("should load configuration", func(t *testing.T) {
+		configServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			fmt.Fprintf(w, `scripts:
+  - name: output
+    command:
+      - ./prober/scripts/output.sh
+`)
+		}))
+		defer configServer.Close()
+
+		sc := NewSafeConfig(prometheus.NewRegistry())
+		err := sc.ReloadConfig(configServer.URL, slog.Default())
+
+		require.NoError(t, err)
+		require.NotNil(t, sc.C)
+
+		t.Run("should return script", func(t *testing.T) {
+			script := sc.C.GetScript("output")
+			require.NotNil(t, script)
+			require.Equal(t, "output", script.Name)
+		})
+
+		t.Run("should return nil if script is not found", func(t *testing.T) {
+			script := sc.C.GetScript("invalid")
+			require.Nil(t, script)
+		})
+	})
+
+	t.Run("should return error for invalid status code", func(t *testing.T) {
+		configServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			http.Error(w, "Not Found", http.StatusNotFound)
+		}))
+		defer configServer.Close()
+
+		sc := NewSafeConfig(prometheus.NewRegistry())
+		err := sc.ReloadConfig(configServer.URL, slog.Default())
+
+		require.Error(t, err)
+	})
+
+	t.Run("should return error for invalid configuration", func(t *testing.T) {
+		configServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			fmt.Fprintf(w, `scripts:
+  - name: output
+    command: ./prober/scripts/output.sh
+`)
+		}))
+		defer configServer.Close()
+
+		sc := NewSafeConfig(prometheus.NewRegistry())
+		err := sc.ReloadConfig(configServer.URL, slog.Default())
 
 		require.Error(t, err)
 	})


### PR DESCRIPTION
It is now possible to specify a url in the `--config.files` flag, so
that the configuration is loaded from the url instead of a local file.
To be able to reload the configuration regularly from the url, a new
flag `--config.reload-interval` has been added. The default value is 1h,
which means that the configuration is reloaded every hour.

Closes #219 
Closes #218
