### PR TITLE
Include FreeBSD to the Go build constraint

### DIFF
--- a/cmd/main_unix.go
+++ b/cmd/main_unix.go
@@ -1,4 +1,4 @@
-//go:build darwin || linux
+//go:build darwin || linux || freebsd
 
 package main
 


### PR DESCRIPTION
Add FreeBSD support, which is currently missing from the `go:build` list, even though the file's actual code (channel setup, calling run(), exiting with its return code) has nothing OS-specific in it.